### PR TITLE
Support mihomo apis

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -364,7 +364,7 @@ impl App {
     pub fn first_run(clashtui_cfg_dir: &PathBuf, symbols: &SharedSymbols) -> Result<()> {
         fs::create_dir_all(clashtui_cfg_dir.join("profiles"))?;
         fs::create_dir_all(clashtui_cfg_dir.join("templates"))?;
-        fs::File::create(clashtui_cfg_dir.join("templates/template_proxy_providers"));
+        fs::File::create(clashtui_cfg_dir.join("templates/template_proxy_providers"))?;
         fs::write(clashtui_cfg_dir.join("config.toml"), &symbols.default_clash_cfg_content)?;
         fs::write(clashtui_cfg_dir.join("basic_clash_config.yaml"), &symbols.default_basic_clash_cfg_content)?;
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -10,7 +10,7 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::env;
 use std::ops::{Deref, DerefMut};
-use std::process::Command;
+use std::process::{Command, Output};
 use std::rc::Rc;
 use std::{
     fs::{self, read_dir, File},
@@ -194,6 +194,18 @@ impl App {
                     Ok(output) => {
                         let list_msg: Vec<String> =
                             output.lines().map(|line| line.trim().to_string()).collect();
+                        self.popup_list_msg(list_msg);
+                    }
+                    Err(err) => {
+                        self.popup_txt_msg(err.to_string());
+                    }
+                }
+                EventState::WorkDone
+            } else if match_key(key, &self.key_list.clashsrvctl_restart_soft) {
+                match self.clashtui_util.clash_client.restart() {
+                    Ok(output) => {
+                        let list_msg: Vec<String> =
+                            output.lines().map(|line|line.trim().to_string()).collect();
                         self.popup_list_msg(list_msg);
                     }
                     Err(err) => {

--- a/src/app.rs
+++ b/src/app.rs
@@ -185,8 +185,8 @@ impl App {
                 let log = self.clashtui_util.fetch_recent_logs(20);
                 self.popup_list_msg(log);
                 EventState::WorkDone
-            } else if match_key(key, &self.key_list.clashsrvctl_restart) {
-                match self.clashtui_util.clash_srv_ctl(ClashTuiOp::RestartClash) {
+            } else if match_key(key, &self.key_list.clashsrvctl_start) {
+                match self.clashtui_util.clash_srv_ctl(ClashTuiOp::StartClash) {
                     Ok(output) => {
                         let list_msg: Vec<String> =
                             output.lines().map(|line| line.trim().to_string()).collect();
@@ -197,7 +197,7 @@ impl App {
                     }
                 }
                 EventState::WorkDone
-            } else if match_key(key, &self.key_list.clashsrvctl_restart_soft) {
+            } else if match_key(key, &self.key_list.clashsrvctl_restart) {
                 match self.clashtui_util.clash_api.restart(None) {
                     Ok(output) => {
                         let list_msg: Vec<String> =

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,31 +1,27 @@
 use anyhow::Result;
-use crossterm::event::{self, Event, KeyCode, KeyEventKind};
+use crossterm::event::{Event, KeyEventKind};
 use log;
 use log4rs::append::file::FileAppender;
 use log4rs::config::{Appender, Config, Root};
 use log4rs::encode::pattern::PatternEncoder;
-use ratatui::style::{Color, Modifier, Style};
-use ratatui::{prelude::*, widgets::*};
+use ratatui::prelude::*;
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::env;
-use std::ops::{Deref, DerefMut};
-use std::process::{Command, Output};
 use std::rc::Rc;
 use std::{
-    fs::{self, read_dir, File},
-    path::{Path, PathBuf},
+    fs::{self},
+    path::PathBuf,
 };
 
 use crate::clashtui_state::{ClashTuiState, SharedClashTuiState};
 use crate::keys::{match_key, KeyList, SharedKeyList};
 use crate::msgpopup_methods;
-use crate::ui::clashsrvctl_tab::{self, ClashSrvCtlTab};
+use crate::ui::clashsrvctl_tab::ClashSrvCtlTab;
 use crate::ui::profile_tab::ProfileTab;
 use crate::ui::statusbar::ClashTuiStatusBar;
 use crate::ui::ClashTuiOp;
 use crate::ui::{
-    widgets::{helper, ClashTuiListPopup, ClashTuiTabBar, SharedTheme, Theme},
+    widgets::{helper, ClashTuiListPopup, ClashTuiTabBar, Theme},
     EventState, MsgPopup,
 };
 use crate::ui::{SharedSymbols, Symbols};

--- a/src/app.rs
+++ b/src/app.rs
@@ -75,7 +75,7 @@ impl App {
             PathBuf::from(&clashtui_config_dir_str)
         };
 
-        if !clashtui_config_dir.join("basic_clash_config.yaml").exists() {
+        if !clashtui_config_dir.exists(){ //.join("basic_clash_config.yaml").exists() { // weird, shouldn`t we check the dir rather the single file?
             if let Err(err) = fs::create_dir_all(&clashtui_config_dir) {
                 log::error!("{}", err.to_string());
             }

--- a/src/app.rs
+++ b/src/app.rs
@@ -198,7 +198,7 @@ impl App {
                 }
                 EventState::WorkDone
             } else if match_key(key, &self.key_list.clashsrvctl_restart_soft) {
-                match self.clashtui_util.clash_client.restart() {
+                match self.clashtui_util.clash_api.restart(None) {
                     Ok(output) => {
                         let list_msg: Vec<String> =
                             output.lines().map(|line|line.trim().to_string()).collect();

--- a/src/clashtui_state.rs
+++ b/src/clashtui_state.rs
@@ -1,9 +1,5 @@
-use crate::utils::ClashTuiUtil;
-use anyhow::Result;
 use serde::{Deserialize, Serialize};
-use std::cell::RefCell;
 use std::fs::File;
-use std::io::{self, Read, Write};
 use std::rc::Rc;
 
 use crate::utils::SharedClashTuiUtil;

--- a/src/clashtui_state.rs
+++ b/src/clashtui_state.rs
@@ -30,6 +30,8 @@ impl ClashTuiState {
 
         instance.load_status_from_file();
 
+        instance.set_tun(tun.0);
+
         #[cfg(target_os = "windows")]
         {
             let sysproxy = ClashTuiUtil::is_system_proxy_enabled().unwrap_or(false);
@@ -75,6 +77,8 @@ impl ClashTuiState {
     }
     pub fn set_profile(&mut self, profile: String) {
         self.state.profile = profile;
+        let tun = self.clashtui_util.get_tun_mode();
+        self.set_tun(tun.0);
     }
     pub fn get_tun(&self) -> bool {
         self.state.tun

--- a/src/keys/key_list.rs
+++ b/src/keys/key_list.rs
@@ -29,8 +29,8 @@ pub struct KeyList {
     pub template_switch: ClashTuiKeyEvent,
     pub template_create: ClashTuiKeyEvent,
     pub clashsrvctl_select: ClashTuiKeyEvent,
+    pub clashsrvctl_start: ClashTuiKeyEvent,
     pub clashsrvctl_restart: ClashTuiKeyEvent,
-    pub clashsrvctl_restart_soft: ClashTuiKeyEvent,
     pub clashsrvctl_stop: ClashTuiKeyEvent,
 
     pub edit: ClashTuiKeyEvent,
@@ -57,8 +57,8 @@ impl Default for KeyList {
             template_switch: ClashTuiKeyEvent::new(KeyCode::Char('t')),
             template_create: ClashTuiKeyEvent::new(KeyCode::Enter),
             clashsrvctl_select: ClashTuiKeyEvent::new(KeyCode::Enter),
+            clashsrvctl_start: ClashTuiKeyEvent::new(KeyCode::Char('S')),
             clashsrvctl_restart: ClashTuiKeyEvent::new(KeyCode::Char('R')),
-            clashsrvctl_restart_soft: ClashTuiKeyEvent::new(KeyCode::Char('r')),
             clashsrvctl_stop: ClashTuiKeyEvent::new(KeyCode::Char('S')),
 
             edit: ClashTuiKeyEvent::new(KeyCode::Char('e')),

--- a/src/keys/key_list.rs
+++ b/src/keys/key_list.rs
@@ -30,6 +30,7 @@ pub struct KeyList {
     pub template_create: ClashTuiKeyEvent,
     pub clashsrvctl_select: ClashTuiKeyEvent,
     pub clashsrvctl_restart: ClashTuiKeyEvent,
+    pub clashsrvctl_restart_soft: ClashTuiKeyEvent,
     pub clashsrvctl_stop: ClashTuiKeyEvent,
 
     pub edit: ClashTuiKeyEvent,
@@ -57,6 +58,7 @@ impl Default for KeyList {
             template_create: ClashTuiKeyEvent::new(KeyCode::Enter),
             clashsrvctl_select: ClashTuiKeyEvent::new(KeyCode::Enter),
             clashsrvctl_restart: ClashTuiKeyEvent::new(KeyCode::Char('R')),
+            clashsrvctl_restart_soft: ClashTuiKeyEvent::new(KeyCode::Char('r')),
             clashsrvctl_stop: ClashTuiKeyEvent::new(KeyCode::Char('S')),
 
             edit: ClashTuiKeyEvent::new(KeyCode::Char('e')),

--- a/src/keys/key_list.rs
+++ b/src/keys/key_list.rs
@@ -59,7 +59,7 @@ impl Default for KeyList {
             clashsrvctl_select: ClashTuiKeyEvent::new(KeyCode::Enter),
             clashsrvctl_start: ClashTuiKeyEvent::new(KeyCode::Char('S')),
             clashsrvctl_restart: ClashTuiKeyEvent::new(KeyCode::Char('R')),
-            clashsrvctl_stop: ClashTuiKeyEvent::new(KeyCode::Char('S')),
+            clashsrvctl_stop: ClashTuiKeyEvent::new(KeyCode::Char('T')),
 
             edit: ClashTuiKeyEvent::new(KeyCode::Char('e')),
             preview: ClashTuiKeyEvent::new(KeyCode::Char('P')),

--- a/src/keys/key_list.rs
+++ b/src/keys/key_list.rs
@@ -1,4 +1,4 @@
-use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+use crossterm::event::{KeyCode, KeyEvent};
 use std::rc::Rc;
 
 pub struct ClashTuiKeyEvent {

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,6 +77,12 @@ fn run_app<B: Backend>(
 ) -> Result<()> {
     let mut last_tick = Instant::now();
     let mut last_ev = EventState::NotConsumed;
+    if app.clashtui_util.err_code != 0
+    {
+        app.popup_txt_msg("The config.yaml might be broken, the progrem will try to fix it".to_string());
+        app.msgpopup.show(); // I think it`s strange to manually set visible after the msg is send
+        terminal.draw(|f| app.draw(f))?;
+    }
     loop {
         terminal.draw(|f| app.draw(f))?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,14 @@
 use anyhow::Result;
 use argh::FromArgs;
 use crossterm::{
-    event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind},
+    event::{self, DisableMouseCapture, EnableMouseCapture},
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
-use log::{info, warn};
-use log4rs;
 use ratatui::prelude::*;
 use std::{
     error::Error,
-    io, panic,
-    time::{Duration, Instant},
+    io, time::{Duration, Instant},
 };
 
 mod app;

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,8 +79,11 @@ fn run_app<B: Backend>(
     let mut last_ev = EventState::NotConsumed;
     if app.clashtui_util.err_code != 0
     {
-        app.popup_txt_msg("The config.yaml might be broken, the progrem will try to fix it".to_string());
-        app.msgpopup.show(); // I think it`s strange to manually set visible after the msg is send
+        app.popup_txt_msg(format!("The {} might be broken, the progrem will try to fix it", match app.clashtui_util.err_code {
+            1 => "basic_clash_config.yaml",
+            _ => "config.toml",
+        }).to_string()); // the output will definitelt be overwritten, but I am lazy to solve. Maybe just show "Config file broken" will be better?
+        app.msgpopup.show(); // it`s strange to manually set visible after the msg is send
         terminal.draw(|f| app.draw(f))?;
     }
     loop {

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,7 +80,6 @@ fn run_app<B: Backend>(
             1 => "basic_clash_config.yaml",
             _ => "config.toml",
         }).to_string()); // the output will definitelt be overwritten, but I am lazy to solve. Maybe just show "Config file broken" will be better?
-        app.msgpopup.show(); // it`s strange to manually set visible after the msg is send
         terminal.draw(|f| app.draw(f))?;
     }
     loop {

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,6 +93,7 @@ fn run_app<B: Backend>(
                 }
             ).as_str();
         } else {
+            if showstr.is_empty() {break;}
             app.popup_txt_msg(showstr);
             terminal.draw(|f| app.draw(f))?;
             drop(err_tarck);

--- a/src/ui/clashsrvctl_tab.rs
+++ b/src/ui/clashsrvctl_tab.rs
@@ -1,8 +1,6 @@
-use anyhow::{anyhow, bail, Result};
-use crossterm::event::{self, Event, KeyCode, KeyEventKind};
-use ratatui::style::{Color, Modifier, Style};
-use ratatui::{prelude::*, widgets::*};
-use std::rc::Rc;
+use anyhow::Result;
+use crossterm::event::{Event, KeyEventKind};
+use ratatui::prelude::*;
 
 use crate::clashtui_state::SharedClashTuiState;
 use crate::keys::{match_key, SharedKeyList};
@@ -10,7 +8,6 @@ use crate::ui::widgets::SharedTheme;
 use crate::ui::ClashTuiOp;
 use crate::ui::SharedSymbols;
 use crate::ui::{widgets::ClashTuiList, EventState, MsgPopup};
-use crate::utils::ClashTuiUtil;
 use crate::utils::SharedClashTuiUtil;
 use crate::{msgpopup_methods, title_methods, visible_methods};
 

--- a/src/ui/confirm_popup.rs
+++ b/src/ui/confirm_popup.rs
@@ -1,5 +1,5 @@
-use anyhow::{bail, Result};
-use crossterm::event::{self, Event, KeyCode, KeyEventKind};
+use anyhow::Result;
+use crossterm::event::{Event, KeyCode, KeyEventKind};
 use ratatui::prelude::*;
 
 use crate::ui::EventState;

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -66,7 +66,7 @@ macro_rules! define_clashtui_operations {
 
 #[cfg(target_os = "linux")]
 define_clashtui_operations!(
-    RestartClash,
+    StartClash,
     StopClash,
     TestClashConfig,
     EnableTun,
@@ -75,7 +75,7 @@ define_clashtui_operations!(
 
 #[cfg(target_os = "windows")]
 define_clashtui_operations!(
-    RestartClash,
+    StartClash,
     StopClash,
     TestClashConfig,
     EnableTun,

--- a/src/ui/msgpopup.rs
+++ b/src/ui/msgpopup.rs
@@ -1,16 +1,14 @@
-use anyhow::{bail, Result};
-use crossterm::event::{self, Event, KeyCode, KeyEventKind};
-use ratatui::style::{Color, Modifier, Style};
+use anyhow::Result;
+use crossterm::event::{Event, KeyCode, KeyEventKind};
+use ratatui::style::{Color, Style};
 use ratatui::{
     prelude::*,
-    widgets::{Block, BorderType, Borders, Clear, Padding, Paragraph, Wrap},
+    widgets::{Block, Borders, Clear, Paragraph, Wrap},
 };
 use std::cmp::{max, min};
-use std::rc::Rc;
 
 use super::widgets::helper;
 use super::EventState;
-use crate::visible_methods;
 
 pub struct MsgPopup {
     title: String,

--- a/src/ui/profile_input.rs
+++ b/src/ui/profile_input.rs
@@ -1,10 +1,9 @@
-use anyhow::{bail, Result};
-use crossterm::event::{self, Event, KeyCode, KeyEventKind};
+use anyhow::Result;
+use crossterm::event::{Event, KeyCode, KeyEventKind};
 use ratatui::{prelude::*, widgets::*};
 
 use crate::ui::widgets::ClashTuiInputPopup;
 use crate::ui::EventState;
-use crate::visible_methods;
 
 pub struct ProfileInputPopup {
     pub name_input: ClashTuiInputPopup,

--- a/src/ui/profile_tab.rs
+++ b/src/ui/profile_tab.rs
@@ -1,22 +1,17 @@
-use anyhow::{bail, Result};
-use crossterm::event::{self, Event, KeyCode, KeyEventKind};
+use anyhow::Result;
+use crossterm::event::{Event, KeyCode, KeyEventKind};
 use log;
-use ratatui::style::{Color, Modifier, Style};
-use ratatui::{prelude::*, widgets::*};
-use std::cell::RefCell;
+use ratatui::prelude::*;
 use std::fs;
-use std::ops::{Deref, DerefMut};
 use std::path::Path;
 use std::rc::Rc;
 use std::{
-    fs::{read_dir, remove_file, File, OpenOptions},
-    io::{self, Read, Write},
+    fs::{remove_file, OpenOptions},
+    io::Write,
 };
 
-use crate::clashtui_state::ClashTuiState;
 use crate::clashtui_state::SharedClashTuiState;
 use crate::keys::{match_key, SharedKeyList};
-use crate::ui::widgets::helper;
 use crate::ui::widgets::{ClashTuiList, SharedTheme};
 use crate::ui::EventState;
 use crate::ui::SharedSymbols;

--- a/src/ui/statusbar.rs
+++ b/src/ui/statusbar.rs
@@ -1,15 +1,14 @@
-use anyhow::{bail, Result};
-use crossterm::event::{self, Event, KeyCode, KeyEventKind};
+use anyhow::Result;
+use crossterm::event::{Event, KeyEventKind};
 use ratatui::prelude::Backend;
-use ratatui::style::{Color, Modifier, Style};
+use ratatui::style::Style;
 use ratatui::{
     prelude::{Frame, Rect, Span},
-    widgets::{Block, BorderType, Borders, Clear, Padding, Paragraph, Wrap},
+    widgets::{Block, Borders, Clear, Paragraph, Wrap},
 };
 
-use crate::clashtui_state::{ClashTuiState, SharedClashTuiState};
+use crate::clashtui_state::SharedClashTuiState;
 use crate::ui::{widgets::SharedTheme, EventState};
-use crate::utils::ClashTuiUtil;
 use crate::visible_methods;
 
 struct Status {

--- a/src/ui/symbols.rs
+++ b/src/ui/symbols.rs
@@ -38,9 +38,9 @@ impl Default for Symbols {
                         j/k/h/l OR Up/Down/Left/Right: Scroll
 
                         ## Global
-                        R: Restart clash service
-                        r: Restart clash core
-                        S: Stop clash service
+                        S: Start clash service
+                        R: Restart clash core
+                        T: sTop clash service
                         H: Locate app home path
                         G: Locate clash config dir
                         L: show recent log

--- a/src/ui/symbols.rs
+++ b/src/ui/symbols.rs
@@ -38,7 +38,8 @@ impl Default for Symbols {
                         j/k/h/l OR Up/Down/Left/Right: Scroll
 
                         ## Global
-                        R: Start clash service
+                        R: Restart clash service
+                        r: Restart clash core
                         S: Stop clash service
                         H: Locate app home path
                         G: Locate clash config dir

--- a/src/ui/widgets/helper.rs
+++ b/src/ui/widgets/helper.rs
@@ -1,4 +1,4 @@
-use ratatui::{prelude::*, widgets::*};
+use ratatui::prelude::*;
 
 /// helper function to create a centered rect using up certain percentage of the available rect `r`
 pub fn centered_percent_rect(percent_x: u16, percent_y: u16, r: Rect) -> Rect {

--- a/src/ui/widgets/list.rs
+++ b/src/ui/widgets/list.rs
@@ -1,9 +1,9 @@
-use anyhow::{bail, Result};
-use crossterm::event::{self, Event, KeyCode, KeyEventKind};
+use anyhow::Result;
+use crossterm::event::{Event, KeyCode, KeyEventKind};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::{prelude::*, widgets::*};
 
-use super::{helper, SharedTheme};
+use super::SharedTheme;
 use crate::ui::EventState;
 use crate::{fouce_methods, visible_methods};
 

--- a/src/ui/widgets/popups/input.rs
+++ b/src/ui/widgets/popups/input.rs
@@ -1,5 +1,5 @@
-use anyhow::{bail, Result};
-use crossterm::event::{self, Event, KeyCode, KeyEventKind};
+use anyhow::Result;
+use crossterm::event::{Event, KeyCode, KeyEventKind};
 use ratatui::{prelude::*, widgets::*};
 
 use crate::ui::EventState;

--- a/src/ui/widgets/popups/list.rs
+++ b/src/ui/widgets/popups/list.rs
@@ -1,6 +1,6 @@
-use anyhow::{bail, Result};
-use crossterm::event::{self, Event, KeyCode, KeyEventKind};
-use ratatui::style::{Color, Modifier, Style};
+use anyhow::Result;
+use crossterm::event::{Event, KeyCode, KeyEventKind};
+use ratatui::style::{Modifier, Style};
 use ratatui::{prelude::*, widgets::*};
 use std::cmp::{max, min};
 

--- a/src/ui/widgets/style.rs
+++ b/src/ui/widgets/style.rs
@@ -1,4 +1,4 @@
-use ratatui::style::{Color, Modifier, Style};
+use ratatui::style::Color;
 use std::rc::Rc;
 
 pub type SharedTheme = Rc<Theme>;

--- a/src/ui/widgets/tabbar.rs
+++ b/src/ui/widgets/tabbar.rs
@@ -1,9 +1,9 @@
-use anyhow::{bail, Result};
-use crossterm::event::{self, Event, KeyCode, KeyEventKind};
+use anyhow::Result;
+use crossterm::event::{Event, KeyCode, KeyEventKind};
 use ratatui::{prelude::*, widgets::*};
 
 use crate::ui::EventState;
-use super::{SharedTheme};
+use super::SharedTheme;
 use crate::visible_methods;
 
 pub struct ClashTuiTabBar {

--- a/src/utils/clash.rs
+++ b/src/utils/clash.rs
@@ -70,7 +70,13 @@ impl ClashTuiUtil {
     pub fn new(clashtui_dir: &PathBuf, profile_dir: &PathBuf) -> Self {
         let mut err_code: i32 = 0; // a trick from chmod, though simply set the flag is enough
         let basic_clash_config_path = Path::new(clashtui_dir).join("basic_clash_config.yaml");
-        let basic_clash_config_value = Self::parse_yaml(basic_clash_config_path.as_path()).unwrap();
+        let basic_clash_config_value: serde_yaml::Value = match Self::parse_yaml(basic_clash_config_path.as_path()) {
+            Ok(r) => r,
+            Err(_) => {
+                err_code += 1;
+                serde_yaml::Value::from("") 
+            }
+        };
         let controller_api = if let Some(controller_api) = basic_clash_config_value
             .get("external-controller")
             .and_then(|v| v.as_str())
@@ -103,7 +109,7 @@ impl ClashTuiUtil {
         let clashtui_config: toml::Value = match toml::from_str(&toml_content) {
             Ok(v) => v,
             Err(e) => {
-                err_code += 2_i32.pow(0);
+                err_code += 2_i32.pow(1);
                 log::error!("[ClashTuiUtil] Unable to load config file:{}", e.to_string());
                 err_ret.clone() // to meet lifetime
         }  
@@ -111,7 +117,7 @@ impl ClashTuiUtil {
         let default_section_of_clashtui_cfg = match clashtui_config.get("default") {
             Some(v) => v,
             None => {
-                err_code += 2_i32.pow(1);
+                err_code += 2_i32.pow(2);
                 log::error!("[ClashTuiUtil] No default section in clashtui config");
                 &err_ret
             }
@@ -122,13 +128,13 @@ impl ClashTuiUtil {
         let clash_srv_name;
 
         if default_section_of_clashtui_cfg != &err_ret{ // precheck to reduce some cost
-            let clash_core_path_str = default_section_of_clashtui_cfg.get_str("clash_core_path", &mut err_code, 2 as u32);
+            let clash_core_path_str = default_section_of_clashtui_cfg.get_str("clash_core_path", &mut err_code, 3 as u32);
             clash_core_path = Path::new(&clash_core_path_str).to_path_buf();
             let clash_cfg_path_str = default_section_of_clashtui_cfg.get_str("clash_cfg_path", &mut err_code, 3 as u32);
             clash_cfg_path = Path::new(&clash_cfg_path_str).to_path_buf();
-            let clash_cfg_dir_str = default_section_of_clashtui_cfg.get_str("clash_cfg_dir", &mut err_code, 4 as u32);
+            let clash_cfg_dir_str = default_section_of_clashtui_cfg.get_str("clash_cfg_dir", &mut err_code, 3 as u32);
             clash_cfg_dir = Path::new(&clash_cfg_dir_str).to_path_buf();
-            clash_srv_name = default_section_of_clashtui_cfg.get_str("clash_srv_name", &mut err_code, 5 as u32);
+            clash_srv_name = default_section_of_clashtui_cfg.get_str("clash_srv_name", &mut err_code, 3 as u32);
         } else {
             clash_core_path = Path::new("").to_path_buf();
             clash_cfg_path = Path::new("").to_path_buf();

--- a/src/utils/clashtui.rs
+++ b/src/utils/clashtui.rs
@@ -39,7 +39,7 @@ pub struct ClashTuiUtil {
     pub clash_cfg_path: PathBuf,
     pub clash_srv_name: String,
 
-    pub clash_client: ClashUtil,
+    pub clash_api: ClashUtil,
     pub clashtui_config: toml::Value,
 
     pub err_code: i32,
@@ -137,7 +137,7 @@ impl ClashTuiUtil {
             clash_cfg_dir,
             clash_cfg_path,
             clash_srv_name,
-            clash_client,
+            clash_api: clash_client,
             clashtui_config,
             err_code,
         };
@@ -152,7 +152,7 @@ impl ClashTuiUtil {
         })
         .to_string();
 
-        let response = self.clash_client
+        let response = self.clash_api
           .config_reload(body)?;
         log::error!("response err: {:?}", response);
         Ok(())
@@ -235,7 +235,7 @@ impl ClashTuiUtil {
             file.read_to_string(&mut file_content)?;
 
             let sub_url = file_content.trim();
-            let mut response = self.clash_client.mock_clash_core(sub_url)?;
+            let mut response = self.clash_api.mock_clash_core(sub_url)?;
 
             profile_yaml_path = self.get_profile_yaml_path(profile_name);
             let directory = profile_yaml_path
@@ -311,7 +311,7 @@ impl ClashTuiUtil {
     }
 
     pub fn download_file(&self, url: &String, path: &PathBuf) -> Result<()> {
-        let mut response = self.clash_client.mock_clash_core(url)?;
+        let mut response = self.clash_api.mock_clash_core(url)?;
 
         let directory = path.parent().ok_or_else(|| anyhow!("Invalid file path"))?;
         if !directory.exists() {
@@ -870,7 +870,7 @@ impl ClashTuiUtil {
 
     pub fn get_tun_mode(&self) -> bool {
         if let Ok(response) = self
-            .clash_client
+            .clash_api
             .config_get()
         {
             if let Ok(serde_json::Value::Object(cfg)) =

--- a/src/utils/clashtui.rs
+++ b/src/utils/clashtui.rs
@@ -1,22 +1,19 @@
-use anyhow::{anyhow, bail, Context, Result};
-use encoding::{DecoderTrap, EncoderTrap, Encoding};
+use anyhow::{anyhow, bail, Result};
 use log;
-use reqwest;
 use serde_derive::Deserialize;
 use std::collections::HashMap;
-use std::io::prelude::*;
 use std::process::Output;
-use std::process::{self, Command};
+use std::process::Command;
 use std::rc::Rc;
 use std::{
     self,
-    fs::{self, create_dir_all, read_dir, read_to_string, File},
+    fs::{self, create_dir_all, read_dir, File},
     io::{BufRead, BufReader},
-    io::{Read, Write},
+    io::Read,
     path::{Path, PathBuf},
 };
 use toml::{self, Value};
-use toml::de::from_str;
+
 
 #[cfg(target_os = "windows")]
 use encoding::all::GBK;

--- a/src/utils/clashtui.rs
+++ b/src/utils/clashtui.rs
@@ -518,7 +518,7 @@ impl ClashTuiUtil {
     #[cfg(target_os = "linux")]
     pub fn clash_srv_ctl(&self, op: ClashTuiOp) -> Result<String> {
         match op {
-            ClashTuiOp::RestartClash => {
+            ClashTuiOp::StartClash => {
                 let output = Command::new("systemctl")
                     .arg("restart")
                     .arg(self.clash_srv_name.as_str())
@@ -551,7 +551,7 @@ impl ClashTuiUtil {
         let nssm_path_str = "nssm";
 
         let output = match op {
-            ClashTuiOp::RestartClash => {
+            ClashTuiOp::StartClash => {
                 Self::start_process_as_admin(
                     nssm_path_str,
                     format!("restart {}", self.clash_srv_name).as_str(),

--- a/src/utils/mihomo.rs
+++ b/src/utils/mihomo.rs
@@ -1,0 +1,111 @@
+pub struct ClashUtil{
+    client: reqwest::blocking::Client,
+    api: String,
+    proxy_addr: String,
+    default_payload: String,
+}
+
+impl ClashUtil {
+    pub fn new(controller_api:String, proxy_addr:String) -> Self{
+        let default_payload = "'{\"path\": \"\", \"payload\": \"\"}'".to_string();
+
+    Self {
+        client: reqwest::blocking::Client::new(),
+        api: controller_api,
+        proxy_addr,
+        default_payload,
+    }
+    }
+    fn get(&self, url:&str, payload:Option<&String>) -> Result<String, reqwest::Error>{
+        let api = format!("{}{}", self.api, url);
+        let response = match payload {
+            Some(kv) => self.client.get(format!("{}{}", api, kv)),
+            None => self.client.get(api),
+        }.send();
+        match response {
+            Ok(r) => r.text(),
+            Err(e) => {
+                log::error!("[ClashUtil] exec {} failed! {}", url, e.status().unwrap());
+                Err(e)
+            }
+        }
+    }
+    fn post(&self, url:&str, payload:Option<&String>) -> Result<String, reqwest::Error>{
+        let api = format!("{}{}", self.api, url);
+        let response = match payload {
+            Some(kv) => self.client.post(api).body(kv.to_owned()),
+            None => self.client.post(api),
+        }.send();
+        match response {
+            Ok(r) => r.text(),
+            Err(e) => {
+                log::error!("[ClashUtil] exec {} failed! {}", url, e.status().unwrap());
+                Err(e)
+            }
+        }
+    }
+    fn put(&self, url:&str, payload:Option<&String>) -> Result<String, reqwest::Error>{
+        let api = format!("{}{}", self.api, url);
+        let response = match payload {
+            Some(kv) => self.client.put(api).body(kv.to_owned()),
+            None => self.client.put(api),
+        }.send();
+        match response {
+            Ok(r) => r.text(),
+            Err(e) => {
+                log::error!("[ClashUtil] exec {} failed! {}", url, e.status().unwrap());
+                Err(e)
+            }
+        }
+    }
+
+    pub fn restart(&self) -> Result<String, reqwest::Error>{
+        self.post("/restart", Some(&self.default_payload))
+    }
+    pub fn update_geo(&self) -> Result<String, reqwest::Error>{
+        self.post("/configs/geo", Some(&self.default_payload))
+    }
+    pub fn log(&self) -> Result<String, reqwest::Error>{
+        self.get("/logs", None)
+    }
+    pub fn traffic(&self) -> Result<String, reqwest::Error>{
+        self.get(&"/traffic", None)
+    }
+    pub fn config_reload(&self, payload:String) -> Result<reqwest::blocking::Response, reqwest::Error>{
+        let request = self.client
+          .put(format!("{}/configs?force=true", self.api))
+          .body(payload)
+          .send();
+    request
+    }
+    pub fn config_get(&self) -> Result<String, reqwest::Error>{
+        self.get(&"/configs", None)
+    }
+    pub fn mock_clash_core(&self, url:&str) -> Result<reqwest::blocking::Response, reqwest::Error>{
+        let proxy = reqwest::Proxy::http(&self.proxy_addr).unwrap();
+        let clash_client = reqwest::blocking::Client::builder()
+        //.user_agent("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Safari/537.36 uacq")
+        //.user_agent("clash-verge/v1.2.0") // url 后不加 `flag=clash` 也会返回 yaml 配置, 而不是返回 base64 编码。
+        .user_agent("clash.meta")
+        .proxy(proxy)
+        .build()
+        .unwrap();
+        let response = clash_client.get(url).send();
+    response
+    }
+}
+
+#[test]
+fn test(){
+    let mut is = true;
+    let sym = ClashUtil::new("http://127.0.0.1:9090".to_string(), "http://127.0.0.1:7890".to_string());
+    match sym.config_get() {
+        Ok(r) => println!("{:?}", r),
+        Err(_) => is = false       
+    }
+    match sym.restart() {
+        Ok(r) => println!("{:?}", r),
+        Err(_) => is = false       
+    }
+    assert!(is)
+}

--- a/src/utils/mihomo.rs
+++ b/src/utils/mihomo.rs
@@ -44,6 +44,7 @@ impl ClashUtil {
             }
         }
     }
+    #[allow(unused)]
     fn put(&self, url:&str, payload:Option<&String>) -> Result<String, reqwest::Error>{
         let api = format!("{}{}", self.api, url);
         let response = match payload {
@@ -58,16 +59,19 @@ impl ClashUtil {
             }
         }
     }
-
+    
     pub fn restart(&self) -> Result<String, reqwest::Error>{
         self.post("/restart", Some(&self.default_payload))
     }
+    #[allow(unused)]
     pub fn update_geo(&self) -> Result<String, reqwest::Error>{
         self.post("/configs/geo", Some(&self.default_payload))
     }
+    #[allow(unused)]
     pub fn log(&self) -> Result<String, reqwest::Error>{
         self.get("/logs", None)
     }
+    #[allow(unused)]
     pub fn traffic(&self) -> Result<String, reqwest::Error>{
         self.get(&"/traffic", None)
     }

--- a/src/utils/mihomo.rs
+++ b/src/utils/mihomo.rs
@@ -41,9 +41,12 @@ pub enum LogLevel {
 #[derive(Debug, Serialize, Deserialize, Default, Clone)]
 #[serde(rename_all = "lowercase")]
 pub enum Tunstack {
-    #[default] Mixed,
+    #[default]
+    #[serde(alias = "Mixed")]
+    Mixed,
     #[serde(alias = "gVisor")]
     Gvisor,
+    #[serde(alias = "System")]
     System,
 }
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,4 +1,4 @@
 mod clashtui;
 mod mihomo;
 
-pub use self::clashtui::{ClashTuiUtil, SharedClashTuiUtil};
+pub use self::clashtui::{ClashTuiUtil, SharedClashTuiUtil, ClashTuiConfigError};

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,3 +1,4 @@
-mod clash;
+mod clashtui;
+mod mihomo;
 
-pub use self::clash::{ClashTuiUtil, SharedClashTuiUtil};
+pub use self::clashtui::{ClashTuiUtil, SharedClashTuiUtil};


### PR DESCRIPTION
fix panic when loading config failed and set those values to ""

impl mihomo apis, the interface is not satble and may change in the future. 

restart the service can be a bad idea when it`s running as system :( , in this case simply send a restart command is much more easier :)

I will work on the rest apis, and I want to know how you want to deal with those broken values.