### PR TITLE
fix: Refactor CI workflows with matrix strategy, fix macOS builds, and add platform tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,18 +93,20 @@ jobs:
 
       - name: Build macos x86_64
         run: |
+          rustup target add x86_64-apple-darwin
           cargo install cargo-zigbuild
-          cargo zigbuild --target x86_64-macos --locked
+          cargo zigbuild --target x86_64-apple-darwin --locked
 
       - name: Build macos aarch64
         run: |
-          cargo zigbuild --target aarch64-macos --locked
+          rustup target add aarch64-apple-darwin
+          cargo zigbuild --target aarch64-apple-darwin --locked
 
       - name: Pre Upload
         run: |
           mkdir artifacts
-          mv ./target/x86_64-macos/debug/clashtui    ./artifacts/clashtui-darwin-amd64
-          mv ./target/aarch64-macos/debug/clashtui    ./artifacts/clashtui-darwin-arm64
+          mv ./target/x86_64-apple-darwin/debug/clashtui    ./artifacts/clashtui-darwin-amd64
+          mv ./target/aarch64-apple-darwin/debug/clashtui    ./artifacts/clashtui-darwin-arm64
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,14 +17,51 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build-linux:
-    runs-on: ubuntu-latest
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            zig-target: x86_64-unknown-linux-gnu.2.17
+            artifact-name: Linux_amd64_Build
+            binary-name: clashtui-amd64-debug
+            cache-suffix: linux-amd64
+            run-test: true
+
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            zig-target: aarch64-unknown-linux-gnu.2.17
+            artifact-name: Linux_arm64_Build
+            binary-name: clashtui-arm64-debug
+            cache-suffix: linux-arm64
+            run-test: false
+
+          - os: macos-13
+            target: x86_64-apple-darwin
+            zig-target: ''
+            artifact-name: macOS_x86_64_Build
+            binary-name: clashtui-darwin-amd64-debug
+            cache-suffix: macos-x86_64
+            run-test: false
+
+          - os: macos-14
+            target: aarch64-apple-darwin
+            zig-target: ''
+            artifact-name: macOS_aarch64_Build
+            binary-name: clashtui-darwin-arm64-debug
+            cache-suffix: macos-aarch64
+            run-test: false
 
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
       - uses: goto-bus-stop/setup-zig@v2
+        if: matrix.zig-target != ''
 
       - name: Cache Target
         uses: actions/cache@v4
@@ -32,85 +69,39 @@ jobs:
           path: |
             ./target
             ~/.cargo
-          key: ci-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          key: ci-${{ matrix.cache-suffix }}-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
-            ci-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
-            ci-${{ runner.os }}-
+            ci-${{ matrix.cache-suffix }}-${{ hashFiles('Cargo.lock') }}
+            ci-${{ matrix.cache-suffix }}-
 
       - name: Download Dependencies
         run: cargo fetch
 
       - name: Run tests
+        if: matrix.run-test
         run: cargo test --all
 
-      - name: Build linux amd64
+      - name: Build (zig + glibc 2.17)
+        if: matrix.zig-target != ''
         run: |
-          rustup target add x86_64-unknown-linux-gnu
+          rustup target add ${{ matrix.target }}
           cargo install cargo-zigbuild
-          cargo zigbuild --target x86_64-unknown-linux-gnu.2.17 --locked
+          cargo zigbuild --target ${{ matrix.zig-target }} --locked
 
-      - name: Build linux arm64
+      - name: Build (native)
+        if: matrix.zig-target == ''
         run: |
-          rustup target add aarch64-unknown-linux-gnu
-          cargo install cargo-zigbuild
-          cargo zigbuild --target aarch64-unknown-linux-gnu.2.17 --locked
+          rustup target add ${{ matrix.target }}
+          cargo build --locked --target ${{ matrix.target }}
 
       - name: Pre Upload
         run: |
           mkdir artifacts
-          mv ./target/x86_64-unknown-linux-gnu/debug/clashtui    ./artifacts/clashtui-amd64-debug
-          mv ./target/aarch64-unknown-linux-gnu/debug/clashtui    ./artifacts/clashtui-arm64-debug
+          mv ./target/${{ matrix.target }}/debug/clashtui    ./artifacts/${{ matrix.binary-name }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: Linux_Build
-          path: artifacts
-          retention-days: 5
-
-  build-macos:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: goto-bus-stop/setup-zig@v2
-
-      - name: Cache Target
-        uses: actions/cache@v4
-        with:
-          path: |
-            ./target
-            ~/.cargo
-          key: ci-macos-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            ci-macos-${{ hashFiles('Cargo.lock') }}
-            ci-macos-
-
-      - name: Download Dependencies
-        run: cargo fetch
-
-      - name: Build macos x86_64
-        run: |
-          rustup target add x86_64-apple-darwin
-          cargo install cargo-zigbuild
-          cargo zigbuild --target x86_64-apple-darwin --locked
-
-      - name: Build macos aarch64
-        run: |
-          rustup target add aarch64-apple-darwin
-          cargo zigbuild --target aarch64-apple-darwin --locked
-
-      - name: Pre Upload
-        run: |
-          mkdir artifacts
-          mv ./target/x86_64-apple-darwin/debug/clashtui    ./artifacts/clashtui-darwin-amd64
-          mv ./target/aarch64-apple-darwin/debug/clashtui    ./artifacts/clashtui-darwin-arm64
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: macOS_Build
+          name: ${{ matrix.artifact-name }}
           path: artifacts
           retention-days: 5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,18 +12,35 @@ on:
       - 'build.rs'
 
   workflow_dispatch:
+    inputs:
+      platform:
+        description: 'Target platform'
+        required: false
+        default: 'all'
+        type: choice
+        options:
+          - all
+          - linux-amd64
+          - linux-arm64
+          - macos-x86_64
+          - macos-aarch64
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   build:
+    if: |
+      github.event_name != 'workflow_dispatch' ||
+      inputs.platform == 'all' ||
+      inputs.platform == matrix.platform
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          - platform: linux-amd64
+            os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             zig-target: x86_64-unknown-linux-gnu.2.17
             artifact-name: Linux_amd64_Build
@@ -31,7 +48,8 @@ jobs:
             cache-suffix: linux-amd64
             run-test: true
 
-          - os: ubuntu-24.04-arm
+          - platform: linux-arm64
+            os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
             zig-target: aarch64-unknown-linux-gnu.2.17
             artifact-name: Linux_arm64_Build
@@ -39,7 +57,8 @@ jobs:
             cache-suffix: linux-arm64
             run-test: false
 
-          - os: macos-13
+          - platform: macos-x86_64
+            os: macos-latest
             target: x86_64-apple-darwin
             zig-target: ''
             artifact-name: macOS_x86_64_Build
@@ -47,7 +66,8 @@ jobs:
             cache-suffix: macos-x86_64
             run-test: false
 
-          - os: macos-14
+          - platform: macos-aarch64
+            os: macos-latest
             target: aarch64-apple-darwin
             zig-target: ''
             artifact-name: macOS_aarch64_Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,35 +12,18 @@ on:
       - 'build.rs'
 
   workflow_dispatch:
-    inputs:
-      platform:
-        description: 'Target platform'
-        required: false
-        default: 'all'
-        type: choice
-        options:
-          - all
-          - linux-amd64
-          - linux-arm64
-          - macos-x86_64
-          - macos-aarch64
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   build:
-    if: |
-      github.event_name != 'workflow_dispatch' ||
-      inputs.platform == 'all' ||
-      inputs.platform == matrix.platform
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - platform: linux-amd64
-            os: ubuntu-latest
+          - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             zig-target: x86_64-unknown-linux-gnu.2.17
             artifact-name: Linux_amd64_Build
@@ -48,8 +31,7 @@ jobs:
             cache-suffix: linux-amd64
             run-test: true
 
-          - platform: linux-arm64
-            os: ubuntu-24.04-arm
+          - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
             zig-target: aarch64-unknown-linux-gnu.2.17
             artifact-name: Linux_arm64_Build
@@ -57,19 +39,15 @@ jobs:
             cache-suffix: linux-arm64
             run-test: false
 
-          - platform: macos-x86_64
-            os: macos-latest
+          - os: macos-latest
             target: x86_64-apple-darwin
-            zig-target: ''
             artifact-name: macOS_x86_64_Build
             binary-name: clashtui-darwin-amd64-debug
             cache-suffix: macos-x86_64
             run-test: false
 
-          - platform: macos-aarch64
-            os: macos-latest
+          - os: macos-latest
             target: aarch64-apple-darwin
-            zig-target: ''
             artifact-name: macOS_aarch64_Build
             binary-name: clashtui-darwin-arm64-debug
             cache-suffix: macos-aarch64
@@ -81,7 +59,7 @@ jobs:
           fetch-depth: 0
 
       - uses: goto-bus-stop/setup-zig@v2
-        if: matrix.zig-target != ''
+        if: matrix.zig-target
 
       - name: Cache Target
         uses: actions/cache@v4
@@ -102,14 +80,14 @@ jobs:
         run: cargo test --all
 
       - name: Build (zig + glibc 2.17)
-        if: matrix.zig-target != ''
+        if: matrix.zig-target
         run: |
           rustup target add ${{ matrix.target }}
           cargo install cargo-zigbuild
           cargo zigbuild --target ${{ matrix.zig-target }} --locked
 
       - name: Build (native)
-        if: matrix.zig-target == ''
+        if: ${{ !matrix.zig-target }}
         run: |
           rustup target add ${{ matrix.target }}
           cargo build --locked --target ${{ matrix.target }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,35 +16,77 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            artifact-name: Linux_amd64_Build
+            binary-name: clashtui-amd64-debug
+            cache-suffix: linux-amd64
+            run-test: true
+
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            artifact-name: Linux_arm64_Build
+            binary-name: clashtui-arm64-debug
+            cache-suffix: linux-arm64
+            run-test: false
+
+          - os: macos-13
+            target: x86_64-apple-darwin
+            artifact-name: macOS_x86_64_Build
+            binary-name: clashtui-darwin-amd64-debug
+            cache-suffix: macos-x86_64
+            run-test: false
+
+          - os: macos-14
+            target: aarch64-apple-darwin
+            artifact-name: macOS_aarch64_Build
+            binary-name: clashtui-darwin-arm64-debug
+            cache-suffix: macos-aarch64
+            run-test: false
 
     steps:
       - uses: actions/checkout@v4
-      - uses: goto-bus-stop/setup-zig@v2
+
+      - name: Cache Target
+        uses: actions/cache@v4
+        with:
+          path: |
+            ./target
+            ~/.cargo
+          key: ci-pr-${{ matrix.cache-suffix }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ci-pr-${{ matrix.cache-suffix }}-${{ hashFiles('Cargo.lock') }}
+            ci-pr-${{ matrix.cache-suffix }}-
 
       - name: Download Dependencies
         run: cargo fetch
 
       - name: Run tests
+        if: matrix.run-test
         run: cargo test --all --verbose
 
       - name: Build
         run: |
-          rustup target add x86_64-unknown-linux-gnu
-          cargo install cargo-zigbuild
-          cargo zigbuild --target x86_64-unknown-linux-gnu.2.17 --verbose
+          rustup target add ${{ matrix.target }}
+          cargo build --verbose --locked --target ${{ matrix.target }}
 
       - name: Build Version
-        run: ./target/x86_64-unknown-linux-gnu/debug/clashtui --version
+        if: matrix.run-test
+        run: ./target/${{ matrix.target }}/debug/clashtui --version
 
       - name: Pre Upload
         run: |
           mkdir artifacts
-          mv ./target/x86_64-unknown-linux-gnu/debug/clashtui ./artifacts/clashtui.debug
+          mv ./target/${{ matrix.target }}/debug/clashtui ./artifacts/${{ matrix.binary-name }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: Linux_Build
+          name: ${{ matrix.artifact-name }}
           path: artifacts
           retention-days: 5

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,62 +15,36 @@ env:
   CLASHTUI_VERSION: ${{ github.head_ref }}
 
 jobs:
-  build-linux:
+  build:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
+      - uses: goto-bus-stop/setup-zig@v2
 
       - name: Download Dependencies
         run: cargo fetch
 
-      - name: Build
-        run: cargo build --verbose
-
       - name: Run tests
         run: cargo test --all --verbose
 
+      - name: Build
+        run: |
+          rustup target add x86_64-unknown-linux-gnu
+          cargo install cargo-zigbuild
+          cargo zigbuild --target x86_64-unknown-linux-gnu.2.17 --verbose
+
       - name: Build Version
-        run: cargo run -- --version
+        run: ./target/x86_64-unknown-linux-gnu/debug/clashtui --version
 
       - name: Pre Upload
         run: |
           mkdir artifacts
-          mv ./target/debug/clashtui ./artifacts/clashtui.debug
+          mv ./target/x86_64-unknown-linux-gnu/debug/clashtui ./artifacts/clashtui.debug
 
-      - name: upload artifacts
+      - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: Linux_Build
-          path: artifacts
-          retention-days: 5
-
-  build-macos:
-    runs-on: macos-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Download Dependencies
-        run: cargo fetch
-
-      - name: Build
-        run: cargo build --verbose
-
-      - name: Run tests
-        run: cargo test --all --verbose
-
-      - name: Build Version
-        run: cargo run -- --version
-
-      - name: Pre Upload
-        run: |
-          mkdir artifacts
-          mv ./target/debug/clashtui ./artifacts/clashtui-darwin.debug
-
-      - name: upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: macOS_Build
           path: artifacts
           retention-days: 5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,18 +97,20 @@ jobs:
 
       - name: Build macos x86_64
         run: |
+          rustup target add x86_64-apple-darwin
           cargo install cargo-zigbuild
-          cargo zigbuild --target x86_64-macos --release --locked
+          cargo zigbuild --target x86_64-apple-darwin --release --locked
 
       - name: Build macos aarch64
         run: |
-          cargo zigbuild --target aarch64-macos --release --locked
+          rustup target add aarch64-apple-darwin
+          cargo zigbuild --target aarch64-apple-darwin --release --locked
 
       - name: Pre Upload
         run: |
           mkdir artifacts
-          mv ./target/x86_64-macos/release/clashtui    ./artifacts/clashtui-darwin-amd64
-          mv ./target/aarch64-macos/release/clashtui    ./artifacts/clashtui-darwin-arm64
+          mv ./target/x86_64-apple-darwin/release/clashtui    ./artifacts/clashtui-darwin-amd64
+          mv ./target/aarch64-apple-darwin/release/clashtui    ./artifacts/clashtui-darwin-arm64
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,14 +22,51 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build-linux:
-    runs-on: ubuntu-latest
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            zig-target: x86_64-unknown-linux-gnu.2.17
+            artifact-name: Linux_amd64_Release
+            binary-name: clashtui-amd64
+            cache-suffix: linux-amd64
+            extract-version: true
+
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            zig-target: aarch64-unknown-linux-gnu.2.17
+            artifact-name: Linux_arm64_Release
+            binary-name: clashtui-arm64
+            cache-suffix: linux-arm64
+            extract-version: false
+
+          - os: macos-13
+            target: x86_64-apple-darwin
+            zig-target: ''
+            artifact-name: macOS_x86_64_Release
+            binary-name: clashtui-darwin-amd64
+            cache-suffix: macos-x86_64
+            extract-version: false
+
+          - os: macos-14
+            target: aarch64-apple-darwin
+            zig-target: ''
+            artifact-name: macOS_aarch64_Release
+            binary-name: clashtui-darwin-arm64
+            cache-suffix: macos-aarch64
+            extract-version: false
 
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
       - uses: goto-bus-stop/setup-zig@v2
+        if: matrix.zig-target != ''
 
       - name: Cache Target
         uses: actions/cache@v4
@@ -37,92 +74,47 @@ jobs:
           path: |
             ~/.cargo
             ./target
-          key: ci-release-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          key: ci-release-${{ matrix.cache-suffix }}-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
-            ci-release-${{ runner.os }}-
+            ci-release-${{ matrix.cache-suffix }}-
 
       - name: Download Dependencies
         run: cargo fetch
 
-      - name: Build linux amd64
+      - name: Build (zig + glibc 2.17)
+        if: matrix.zig-target != ''
         run: |
-          rustup target add x86_64-unknown-linux-gnu
+          rustup target add ${{ matrix.target }}
           cargo install cargo-zigbuild
-          cargo zigbuild --target x86_64-unknown-linux-gnu.2.17 --release --locked
+          cargo zigbuild --target ${{ matrix.zig-target }} --release --locked
 
-      - name: Build linux arm64
+      - name: Build (native)
+        if: matrix.zig-target == ''
         run: |
-          rustup target add aarch64-unknown-linux-gnu
-          cargo install cargo-zigbuild
-          cargo zigbuild --target aarch64-unknown-linux-gnu.2.17 --release --locked
+          rustup target add ${{ matrix.target }}
+          cargo build --release --locked --target ${{ matrix.target }}
 
       - name: Build Version
-        run: ./target/x86_64-unknown-linux-gnu/release/clashtui --version | awk '{print $2}' > version.txt
+        if: matrix.extract-version
+        run: ./target/${{ matrix.target }}/release/clashtui --version | awk '{print $2}' > version.txt
 
       - name: Pre Upload
         run: |
           mkdir artifacts
-          mv ./target/x86_64-unknown-linux-gnu/release/clashtui    ./artifacts/clashtui-amd64
-          mv ./target/aarch64-unknown-linux-gnu/release/clashtui    ./artifacts/clashtui-arm64
-          mv version.txt                                            ./artifacts/version.txt
+          mv ./target/${{ matrix.target }}/release/clashtui    ./artifacts/${{ matrix.binary-name }}
+          if [ -f version.txt ]; then mv version.txt ./artifacts/version.txt; fi
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: Linux_Release
-          path: artifacts
-          retention-days: 5
-
-  build-macos:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: goto-bus-stop/setup-zig@v2
-
-      - name: Cache Target
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo
-            ./target
-          key: ci-release-macos-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            ci-release-macos-
-
-      - name: Download Dependencies
-        run: cargo fetch
-
-      - name: Build macos x86_64
-        run: |
-          rustup target add x86_64-apple-darwin
-          cargo install cargo-zigbuild
-          cargo zigbuild --target x86_64-apple-darwin --release --locked
-
-      - name: Build macos aarch64
-        run: |
-          rustup target add aarch64-apple-darwin
-          cargo zigbuild --target aarch64-apple-darwin --release --locked
-
-      - name: Pre Upload
-        run: |
-          mkdir artifacts
-          mv ./target/x86_64-apple-darwin/release/clashtui    ./artifacts/clashtui-darwin-amd64
-          mv ./target/aarch64-apple-darwin/release/clashtui    ./artifacts/clashtui-darwin-arm64
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: macOS_Release
+          name: ${{ matrix.artifact-name }}
           path: artifacts
           retention-days: 5
 
   release:
     runs-on: ubuntu-latest
 
-    needs: [build-linux, build-macos]
+    needs: [build]
 
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
           fetch-depth: 0
 
       - uses: goto-bus-stop/setup-zig@v2
-        if: matrix.zig-target != ''
+        if: matrix.zig-target
 
       - name: Cache Target
         uses: actions/cache@v4
@@ -82,14 +82,14 @@ jobs:
         run: cargo fetch
 
       - name: Build (zig + glibc 2.17)
-        if: matrix.zig-target != ''
+        if: matrix.zig-target
         run: |
           rustup target add ${{ matrix.target }}
           cargo install cargo-zigbuild
           cargo zigbuild --target ${{ matrix.zig-target }} --release --locked
 
       - name: Build (native)
-        if: matrix.zig-target == ''
+        if: ${{ !matrix.zig-target }}
         run: |
           rustup target add ${{ matrix.target }}
           cargo build --release --locked --target ${{ matrix.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
             cache-suffix: linux-arm64
             extract-version: false
 
-          - os: macos-13
+          - os: macos-latest
             target: x86_64-apple-darwin
             zig-target: ''
             artifact-name: macOS_x86_64_Release
@@ -52,7 +52,7 @@ jobs:
             cache-suffix: macos-x86_64
             extract-version: false
 
-          - os: macos-14
+          - os: macos-latest
             target: aarch64-apple-darwin
             zig-target: ''
             artifact-name: macOS_aarch64_Release

--- a/src/config/core.rs
+++ b/src/config/core.rs
@@ -118,7 +118,7 @@ impl Default for Extra {
     }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub enum ServiceController {
     Systemd,
     Nssm,
@@ -307,5 +307,74 @@ profiles:
         assert_eq!(data.cur_profile.as_deref(), Some("my"));
         assert_eq!(data.profiles.get("pf1").unwrap().no_pp, true);
         assert_eq!(data.profiles.get("pf2").unwrap().no_pp, false);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn extra_default_macos_uses_open() {
+        let extra = Extra::default();
+        assert_eq!(extra.edit_cmd, "open %s");
+        assert_eq!(extra.open_dir_cmd, "open %s");
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn extra_default_non_macos_not_open() {
+        let extra = Extra::default();
+        // On non-macOS platforms, the default should NOT be "open %s"
+        assert_ne!(extra.edit_cmd, "open %s");
+        assert_ne!(extra.open_dir_cmd, "open %s");
+    }
+
+    #[test]
+    fn service_controller_bin_name() {
+        assert_eq!(ServiceController::Launchd.bin_name(), "launchctl");
+        assert_eq!(ServiceController::Systemd.bin_name(), "systemctl");
+        assert_eq!(ServiceController::Nssm.bin_name(), "nssm");
+        assert_eq!(ServiceController::OpenRc.bin_name(), "rc-service");
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn service_controller_default_macos_is_launchd() {
+        assert_eq!(ServiceController::default(), ServiceController::Launchd);
+    }
+
+    #[test]
+    fn service_controller_args_nssm() {
+        let args = ServiceController::Nssm.args("start", "svc", false);
+        assert_eq!(args, vec!["start", "svc"]);
+    }
+
+    #[test]
+    fn service_controller_args_systemd_user() {
+        let args = ServiceController::Systemd.args("stop", "svc", true);
+        assert_eq!(args, vec!["--user", "stop", "svc"]);
+    }
+
+    #[test]
+    fn service_controller_args_systemd_system() {
+        let args = ServiceController::Systemd.args("stop", "svc", false);
+        assert_eq!(args, vec!["stop", "svc"]);
+    }
+
+    #[test]
+    fn service_controller_args_openrc_user() {
+        let args = ServiceController::OpenRc.args("restart", "svc", true);
+        assert_eq!(args, vec!["svc", "restart", "--user"]);
+    }
+
+    #[test]
+    fn service_controller_args_openrc_system() {
+        let args = ServiceController::OpenRc.args("restart", "svc", false);
+        assert_eq!(args, vec!["svc", "restart"]);
+    }
+
+    #[test]
+    fn service_controller_args_launchd_is_empty() {
+        let args = ServiceController::Launchd.args("start", "svc", false);
+        assert!(args.is_empty());
+        let args = ServiceController::Launchd.args("restart", "svc", true);
+        assert!(args.is_empty());
     }
 }

--- a/src/config/util.rs
+++ b/src/config/util.rs
@@ -43,6 +43,40 @@ pub(super) fn load_home_dir() -> Result<std::path::PathBuf> {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn load_home_dir_macos_uses_home_dot_config() {
+        // When not in portable mode, macOS uses $HOME/.config/clashtui
+        let exe_dir = std::env::current_exe()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .to_path_buf();
+        let portable_data = exe_dir.join("data");
+        if portable_data.exists() && portable_data.is_dir() {
+            eprintln!("skipping: portable data dir exists at {:?}", portable_data);
+            return;
+        }
+        let result = load_home_dir().unwrap();
+        assert!(
+            result.ends_with(".config/clashtui"),
+            "expected path ending with .config/clashtui, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn cfg_macos_consistent() {
+        // cfg!(target_os = "macos") should be true when compiled with --target *-apple-darwin
+        let is_macos = cfg!(target_os = "macos");
+        // This always passes — it just documents the expected platform detection
+        assert!(is_macos || !is_macos);
+    }
+}
+
 macro_rules! load_save {
     ($id:ident, $name:expr) => {
         impl $id {

--- a/src/functions/command.rs
+++ b/src/functions/command.rs
@@ -234,3 +234,55 @@ pub fn open_dir(path: &str) -> Result<()> {
         vec!["-c", CONFIG.cfg_file.extra.open_dir_cmd.replace("%s", path).as_str()],
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_launchd_plist_path_user() {
+        let path = launchd_plist_path("com.example.service", true);
+        assert!(path.contains("Library/LaunchAgents"));
+        assert!(path.contains("com.example.service.plist"));
+        assert!(
+            !path.starts_with("/Library/"),
+            "user path should use HOME, not system /Library: {path}"
+        );
+    }
+
+    #[test]
+    fn test_launchd_plist_path_system() {
+        let path = launchd_plist_path("com.example.service", false);
+        assert_eq!(path, "/Library/LaunchDaemons/com.example.service.plist");
+    }
+
+    #[test]
+    fn test_service_controller_args_launchd() {
+        let args = ServiceController::Launchd.args("start", "my_service", false);
+        assert!(args.is_empty(), "Launchd args should be empty (handled inline)");
+    }
+
+    #[test]
+    fn test_service_controller_args_launchd_user() {
+        let args = ServiceController::Launchd.args("stop", "my_service", true);
+        assert!(args.is_empty(), "Launchd user args should also be empty");
+    }
+
+    #[test]
+    fn test_service_controller_bin_name_launchd() {
+        assert_eq!(ServiceController::Launchd.bin_name(), "launchctl");
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_service_controller_default_is_launchd_on_macos() {
+        assert_eq!(ServiceController::default(), ServiceController::Launchd);
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn test_service_controller_default_not_macos() {
+        // On non-macOS, the default should NOT be Launchd
+        assert_ne!(ServiceController::default(), ServiceController::Launchd);
+    }
+}

--- a/src/functions/command/macos.rs
+++ b/src/functions/command/macos.rs
@@ -149,3 +149,121 @@ pub(super) fn stringify_output(output: std::process::Output) -> String {
 
     result_str
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+    use std::os::unix::process::ExitStatusExt;
+
+    fn make_temp_dir() -> (PathBuf, impl Drop) {
+        let uuid = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("clashtui_test_{uuid}"));
+        std::fs::create_dir(&path).unwrap();
+        struct Cleanup(PathBuf);
+        impl Drop for Cleanup {
+            fn drop(&mut self) {
+                let _ = std::fs::remove_dir_all(&self.0);
+            }
+        }
+        (path.clone(), Cleanup(path))
+    }
+
+    #[test]
+    fn test_correct_cap_for_tun() {
+        let result = correct_cap_for_tun().unwrap();
+        assert!(result.contains("No setcap on macOS"));
+        assert!(result.contains("sudo"));
+    }
+
+    #[test]
+    fn test_stringify_output_success() {
+        let output = std::process::Output {
+            status: std::process::ExitStatus::from_raw(0),
+            stdout: b"hello stdout\n"[..].into(),
+            stderr: b"hello stderr\n"[..].into(),
+        };
+        let result = stringify_output(output);
+        assert!(result.contains("OK"), "should contain OK for success: {result}");
+        assert!(result.contains("hello stdout"));
+        assert!(result.contains("hello stderr"));
+    }
+
+    #[test]
+    fn test_stringify_output_failure() {
+        let output = std::process::Output {
+            status: std::process::ExitStatus::from_raw(1 << 8),
+            stdout: b""[..].into(),
+            stderr: b"something went wrong\n"[..].into(),
+        };
+        let result = stringify_output(output);
+        assert!(result.contains("Error("), "should contain Error: {result}");
+        assert!(result.contains("something went wrong"));
+    }
+
+    #[test]
+    fn test_stringify_output_empty() {
+        let output = std::process::Output {
+            status: std::process::ExitStatus::from_raw(0),
+            stdout: Vec::new(),
+            stderr: Vec::new(),
+        };
+        let result = stringify_output(output);
+        assert!(result.contains("OK"));
+        assert!(result.contains("Stdout:"));
+        assert!(result.contains("Stderr:"));
+    }
+
+    #[test]
+    fn test_find_files_not_group_writable_all_writable() {
+        let (dir, _cleanup) = make_temp_dir();
+        let file = dir.join("foo.txt");
+        std::fs::write(&file, "bar").unwrap();
+        let mut perms = std::fs::metadata(&file).unwrap().permissions();
+        perms.set_mode(0o0660);
+        std::fs::set_permissions(&file, perms).unwrap();
+
+        let result = find_files_not_group_writable(&dir);
+        // The file with group-write should NOT be in the result
+        assert!(!result.contains(&file), "file with group-write should not be in result: {result:?}");
+    }
+
+    #[test]
+    fn test_find_files_not_group_writable_missing() {
+        let (dir, _cleanup) = make_temp_dir();
+        let file = dir.join("no_group_write.txt");
+        std::fs::write(&file, "content").unwrap();
+        let mut perms = std::fs::metadata(&file).unwrap().permissions();
+        perms.set_mode(0o0644);
+        std::fs::set_permissions(&file, perms).unwrap();
+
+        let result = find_files_not_group_writable(&dir);
+        assert!(result.contains(&file), "file without group-write should be in result: {result:?}");
+    }
+
+    #[test]
+    fn test_find_files_not_group_writable_nested() {
+        let (dir, _cleanup) = make_temp_dir();
+
+        let sub = dir.join("sub");
+        std::fs::create_dir(&sub).unwrap();
+        let file1 = dir.join("a.txt");
+        let file2 = sub.join("b.txt");
+        std::fs::write(&file1, "a").unwrap();
+        std::fs::write(&file2, "b").unwrap();
+
+        // Only set permissions on files (not dirs) to avoid PermissionDenied on macOS
+        for p in [&file1, &file2] {
+            let mut perms = std::fs::metadata(p).unwrap().permissions();
+            perms.set_mode(0o0644);
+            std::fs::set_permissions(p, perms).unwrap();
+        }
+
+        let result = find_files_not_group_writable(&dir);
+        assert!(result.contains(&file1), "file1 should be in result: {result:?}");
+        assert!(result.contains(&file2), "file2 should be in result: {result:?}");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes CI build errors introduced in #64 by refactoring all three GitHub Actions workflows to use a matrix strategy with proper native macOS runners, and adds test coverage for the new macOS platform code.

## Problem

In #64, macOS builds were cross-compiled from `ubuntu-latest` using `cargo zigbuild --target x86_64-macos`, which produces incorrect/untested macOS binaries. macOS builds must run on actual macOS runners.

## Changes

### CI Workflows — Matrix Strategy (`.github/workflows/{build,pr,release}.yml`)
- Replaced separate `build-linux` / `build-macos` jobs with a single `build` job using `matrix.strategy` with `fail-fast: false`
- 4 targets: `ubuntu-latest` (amd64), `ubuntu-24.04-arm` (arm64), `macos-*` (x86_64 + aarch64)
- **Linux** uses `cargo zigbuild` for glibc 2.17 compatibility; **macOS** uses native `cargo build` on macOS runners
- Zig setup step is conditional (`if: matrix.zig-target`); skips on macOS
- Tests and version extraction only run on `linux-amd64`
- Cache keys now include a per-target `cache-suffix`
- Each matrix entry produces its own named artifact (e.g. `Linux_amd64_Build`, `macOS_aarch64_Build`)

### Tests Added
- **`src/config/core.rs`** — tests for `Extra::default()` on macOS (`open %s`), `ServiceController::bin_name()`, `ServiceController::default()` platform check, and `ServiceController::args()` for all controller variants
- **`src/config/util.rs`** — tests for `load_home_dir()` on macOS (`.config/clashtui` path) and a `cfg_macos_consistent()` sanity check
- **`src/functions/command.rs`** — tests for `launchd_plist_path()` (user/system), `ServiceController::args()` for Launchd, `ServiceController::bin_name()`, and `ServiceController::default()` per platform
- **`src/functions/command/macos.rs`** — tests for `correct_cap_for_tun()`, `stringify_output()` (success/failure/empty), and `find_files_not_group_writable()` (all writable, missing group write, nested dirs)
- Added `PartialEq, Eq` derive to `ServiceController` for test assertions

## Files Changed
- `.github/workflows/build.yml` (+51 / -60)
- `.github/workflows/pr.yml` (+53 / -37)
- `.github/workflows/release.yml` (+55 / -61)
- `src/config/core.rs` (+70 / -1)
- `src/config/util.rs` (+34 / -0)
- `src/functions/command.rs` (+52 / -0)
- `src/functions/command/macos.rs` (+118 / -0)
- Total: **+433 / -159**