### PR TITLE
docs: Add Windows support design documentation

### DIFF
--- a/docs/clashtui_feature_design_en.md
+++ b/docs/clashtui_feature_design_en.md
@@ -50,6 +50,22 @@ ClashTui Core file structure design:
     └── sing-box -> /usr/bin/sing-box
 ```
 
+## ServiceController
+
+ClashTui supports multiple service managers, with the default automatically selected at compile time based on the platform:
+
+| Controller      | Platform        | Implementation               | Description                  |
+|-----------------|-----------------|------------------------------|------------------------------|
+| Systemd         | Linux (default) | `systemctl` CLI              | systemd service management   |
+| OpenRc          | Linux (optional)| `rc-service` CLI             | OpenRC service management    |
+| WindowsService  | Windows (default)| `windows-service` Rust crate | Direct Windows SCM API       |
+| Launchd         | macOS (default) | `launchctl` CLI              | launchd service management   |
+
+Compile-time defaults:
+- `cfg!(windows)` → WindowsService
+- `cfg!(target_os = "macos")` → Launchd
+- Other → Systemd
+
 ## ClashTui clashtui.db Format Design
 
 ```yaml
@@ -819,3 +835,268 @@ macOS and Linux use a unified Unix group permission model for managing Core file
 | Startup permission check/repair | ✅ | ✅ (real impl in `macos.rs`, not stubs) |
 
 Principle: On macOS system mode, Core services run as root (required for TUN), while regular users gain file read/write access through the `admin` group. At startup, ClashTui checks the Core directory's SGID bit, group consistency, and group writability. If inconsistent, it repairs via `sudo chmod g+s` / `sudo chown :<group>` / `sudo chmod g+w`.
+
+## Support Windows
+
+### Windows Core File Structure
+
+ClashTui Core file structure (System mode, e.g. `C:\Program Files\clashtui`):
+
+```
+.
+├── bin
+│   └── clashtui.exe
+├── mihomo
+│   ├── config                          # Core Config Dir
+│   │   └── config.yaml                 # Core Config Path
+│   └── mihomo.exe -> C:\bin\mihomo.exe # or place .exe directly
+└── sing-box
+    ├── config                          # Core Config Dir
+    │   └── config.json                 # Core Config Path
+    └── sing-box.exe -> C:\bin\sing-box.exe
+```
+
+User mode default path is `%LOCALAPPDATA%\clashtui` (e.g. `C:\Users\<User>\AppData\Local\clashtui`).
+
+ClashTui config file structure is the same as Linux/macOS, stored at `%APPDATA%\clashtui` (e.g. `C:\Users\<User>\AppData\Roaming\clashtui`).
+
+Like Linux/macOS, Windows supports symlinks (`mklink` / `mklink /D`) to point to binary paths, but requires Administrator privileges. Without admin rights, users can place `.exe` files directly.
+
+### Core Services Management (Windows SCM API)
+
+Windows uses the Rust [`windows-service`](https://crates.io/crates/windows-service) crate to directly call the Windows SCM (Service Control Manager) API — no external tools required (sc.exe / WinSW / NSSM). Both Clash Verge Rev and FlClash use the same approach.
+
+#### systemd vs launchd vs Windows SCM Comparison
+
+| Operation       | Linux (systemd)                          | macOS (launchd)                               | Windows (SCM API)                                      |
+|-----------------|------------------------------------------|-----------------------------------------------|--------------------------------------------------------|
+| **User Mode**   |                                          |                                               |                                                        |
+| install service | `systemctl --user link <unit>`           | (plist in `~/Library/LaunchAgents/` = installed)| `ServiceManager::create_service()`                     |
+| uninstall       | `systemctl --user disable <name>`        | (delete plist + `launchctl bootout`)           | `service.stop()` → `service.delete()`                  |
+| start service   | `systemctl --user start <name>`          | `launchctl bootstrap gui/$UID <plist>`         | `service.start()`                                      |
+| stop service    | `systemctl --user stop <name>`           | `launchctl bootout gui/$UID/<name>`            | `service.stop()`                                       |
+| check status    | `systemctl --user is-active <name>`      | `launchctl print gui/$UID/<name>`              | `service.query_status()` → `ServiceState`              |
+| crash restart   | `Restart=always` (unit file)             | `KeepAlive=true` (plist)                       | `SERVICE_CONFIG_FAILURE_ACTIONS` (via SCM API)          |
+| **System Mode** |                                          |                                               |                                                        |
+| install service | `sudo systemctl link <unit>`             | `sudo launchctl bootstrap system <plist>`      | `ServiceManager::create_service()` (Admin required)     |
+| uninstall       | `sudo systemctl disable <name>`          | `sudo launchctl bootout system/<name>`         | `stop()` → `delete()`  (Admin required)                 |
+| start service   | `sudo systemctl start <name>`            | `sudo launchctl bootstrap system <plist>`      | `service.start()` (Admin required)                      |
+| stop service    | `sudo systemctl stop <name>`             | `sudo launchctl bootout system/<name>`         | `service.stop()` (Admin required)                       |
+| check status    | `systemctl is-active <name>`             | `sudo launchctl print system/<name>`           | `service.query_status()`                                |
+| TUN access      | `setcap` (Linux capabilities)            | root (no setcap)                               | Administrator suffices (LocalSystem by default)         |
+
+Key differences:
+- **Zero external dependencies**: The `windows-service` crate calls the SCM API directly — the SCM is a core Windows OS component. No third-party tools need to be installed by the user.
+- **Type-safe API**: Uses Rust's strong typing (`ServiceState`, `ServiceType`, `ServiceStartType`) instead of parsing CLI string output, avoiding parsing errors.
+- **Crash restart**: Configured via SCM API `ChangeServiceConfig2W` + `SERVICE_CONFIG_FAILURE_ACTIONS`. The `windows-service` crate doesn't expose this directly yet; may require supplemental `windows` crate calls, or post-install `sc failure` configuration.
+
+#### Installation Example
+
+ClashTui calls the SCM API directly (no external commands):
+
+```rust
+// Pseudocode
+use windows_service::service_manager::{ServiceManager, ServiceManagerAccess};
+
+let manager = ServiceManager::local_computer(None, ServiceManagerAccess::CREATE_SERVICE)?;
+let service = manager.create_service(
+    &ServiceInfo {
+        name: "clashtui_mihomo".into(),
+        display_name: "ClashTui Mihomo".into(),
+        service_type: ServiceType::OWN_PROCESS,
+        start_type: ServiceStartType::AutoStart,
+        error_control: ServiceErrorControl::Normal,
+        executable_path: r"C:\Program Files\clashtui\mihomo\mihomo.exe",
+        launch_arguments: vec![r#"-d "C:\Program Files\clashtui\mihomo\config""#.into()],
+        dependencies: vec![],
+        account_name: None, // LocalSystem
+        account_password: None,
+    },
+    ServiceAccess::START | ServiceAccess::STOP,
+)?;
+```
+
+#### CoreSrvCtl New Operations
+
+Since Windows command line is inconvenient, CoreSrvCtl tab provides three additional operations on Windows:
+
+**1. Install Srv**
+
+- Calls SCM API via the `windows-service` crate: `ServiceManager::create_service()`
+- service type: `OWN_PROCESS`, start type: `AutoStart`, account: `LocalSystem` (Administrator privileges)
+- `executable_path` = `bin_path`, `launch_arguments` derived from CoreType
+- After installation, service status becomes `installed`
+- Optional: post-install crash restart configuration via `sc failure`
+
+**2. Uninstall Srv**
+
+- If the service is running, first `service.stop()`
+- Then `service.delete()` to remove the service
+- After uninstallation, service status becomes `uninstalled`
+
+**3. Toggle System Proxy**
+
+Based on clashtui v0.2.3 implementation, system proxy is toggled via Windows Registry:
+
+| Interface              | Action                                                                    |
+|------------------------|--------------------------------------------------------------------------|
+| Check proxy status     | Read `HKCU\Software\Microsoft\Windows\CurrentVersion\Internet Settings\ProxyEnable` (REG_DWORD): `0` = disabled, `1` = enabled |
+| Enable system proxy    | `ProxyEnable` → `1`; `ProxyServer` → `127.0.0.1:<port>`; `ProxyOverride` → `<-loopback>`; broadcast `WM_SETTINGCHANGE` |
+| Disable system proxy   | `ProxyEnable` → `0`; broadcast `WM_SETTINGCHANGE`                        |
+
+The proxy port is obtained from the core's mixed port (typically `7890`) via REST API `GET /configs` reading the mixed inbound's `listen_port`.
+
+Implementation: Use the `winreg` crate to directly manipulate the registry (recommended for better error handling). After modifying registry values, call `SendMessageTimeoutW(HWND_BROADCAST, WM_SETTINGCHANGE, ...)` to notify the system to refresh proxy settings.
+
+#### CoreSrvCtl Operation List (Windows)
+
+| Operation        | Description                                                 |
+|------------------|-------------------------------------------------------------|
+| Stop Service     | Stop the current core's service                             |
+| Start Service    | Start the current core's service                            |
+| Install Srv      | Install current core as Windows Service (SCM API create_service) |
+| Uninstall Srv    | Uninstall current core's Windows Service (stop then delete) |
+| Toggle SysProxy  | Toggle system proxy (enable/disable)                        |
+| Switch Core      | Switch to the other core (mihomo ↔ sing-box)                |
+| Stop All         | Stop all core services                                      |
+
+#### Service States
+
+| State          | Meaning                                  |
+|----------------|------------------------------------------|
+| `active`       | Service is running                       |
+| `inactive`     | Service installed but not running         |
+| `installed`    | Windows Service registered (not started)    |
+| `uninstalled`  | No Windows Service found (needs Install)    |
+| `?`            | Unable to determine (e.g. insufficient permissions) |
+
+State detection priority:
+1. Query via SCM API `service.query_status()` to get `ServiceState`
+2. `Running` → `"active"`, `Stopped` → `"inactive"`
+3. Service not found (ERROR_SERVICE_DOES_NOT_EXIST) → `"uninstalled"`
+
+### File Permissions
+
+Windows uses NTFS ACL (Access Control List) for file permissions, which is fundamentally different from Unix mode bits.
+
+**Windows strategy:**
+- `check_file_permissions()` → always returns `true` (permissions always considered OK)
+- `repair_file_permissions()` → always returns `Ok("Permissions OK on Windows")` (no repair needed)
+- `correct_cap_for_tun()` → always returns `Ok("No setcap on Windows")` (TUN capabilities managed by the core)
+- `check_startup_perms()` → no-op (skip permission checks)
+
+Rationale: Windows' permission model is based on user/group ACLs — concepts like group sticky bit and mode bits do not exist. Core files running as Administrator have sufficient privileges. The regular user's TUI tool only needs read/write access to `%APPDATA%\clashtui` config directory (which users have by default).
+
+### CoreSrvCtl Tab Windows Adaptation
+
+#### Current State — CoreSrvCtl Operations
+
+```rust
+enum SrvCtlOp {
+    Stop,        // "Stop Service"
+    Restart,     // "Start Service"
+    SwitchCore,  // "Switch Core"
+    StopAll,     // "Stop All Services"
+}
+```
+
+#### Windows Extensions
+
+On Windows, when `ServiceController::default()` returns `WindowsService`, three additional operations are available:
+
+```rust
+#[cfg(windows)]
+SrvCtlOp::Install,       // "Install Service" — SCM API create_service
+#[cfg(windows)]
+SrvCtlOp::Uninstall,     // "Uninstall Service" — stop + delete
+#[cfg(windows)]
+SrvCtlOp::ToggleSysProxy, // "Toggle System Proxy" — registry read/write
+```
+
+**Install** execution logic:
+1. Call `ServiceManager::create_service()` via the `windows-service` crate
+2. service type: `OWN_PROCESS`, account: `LocalSystem`, start: `AutoStart`
+3. `executable_path` = `bin_path`, `launch_arguments` derived from CoreType
+4. Update status to `installed`
+
+**Uninstall** execution logic:
+1. Open service; if running, call `service.stop()`
+2. Then `service.delete()`
+3. Update status to `uninstalled`
+
+**Toggle System Proxy** execution logic:
+1. Read current `ProxyEnable` registry value
+2. If currently disabled → enable: set `ProxyEnable=1`, `ProxyServer=127.0.0.1:<port>`, `ProxyOverride=<-loopback>`, broadcast `WM_SETTINGCHANGE`
+3. If currently enabled → disable: set `ProxyEnable=0`, broadcast `WM_SETTINGCHANGE`
+4. Mixed port obtained from REST API `GET /configs` mixed inbound config
+
+#### Status Query Adaptation
+
+The current srvctl status query hardcodes `systemctl is-active` for non-Launchd cases. It needs to be adapted:
+
+```rust
+match ServiceController::default() {
+    ServiceController::Launchd => launchd_status(...),
+    ServiceController::WindowsService => windows_service_status(...), // new
+    _ => systemd_status(...),
+}
+```
+
+`windows_service_status()` implementation:
+1. Open service via `windows-service` crate → `service.query_status()`
+2. Parse `ServiceState`:
+   - `Running` → `"active"`
+   - `Stopped` / `Paused` etc. → `"inactive"`
+   - `ERROR_SERVICE_DOES_NOT_EXIST` → `"uninstalled"`
+
+### Install Script
+
+To lower the deployment barrier for Windows users, a PowerShell install script (`install.ps1`) handles the following:
+
+#### Features
+
+1. **Choose install directory**: Default `C:\Program Files\clashtui`, user can specify a custom path via parameter (e.g. `D:\clashtui`)
+2. **Create directory structure**: Automatically creates `mihomo/config/`, `sing-box/config/` etc.
+3. **Copy files**:
+   - Copy or prompt user to place `mihomo.exe` / `sing-box.exe` in the respective core directory
+   - Copy `clashtui.exe` to `bin/`
+4. **Register Windows Services**: clashtui registers both core services via the `windows-service` crate's SCM API (no external tools needed)
+5. **Generate config.yaml template**: Auto-fill `bin_path` and `config_dir` with the user's chosen install directory
+
+#### Usage
+
+```powershell
+# Default install to C:\Program Files\clashtui
+.\install.ps1
+
+# Install to custom directory
+.\install.ps1 -InstallDir "D:\MyTools\clashtui"
+```
+
+#### Windows-specific Parameters
+
+| Parameter      | Default                              | Description                 |
+|----------------|--------------------------------------|-----------------------------|
+| `-InstallDir`  | `C:\Program Files\clashtui`          | Installation root directory |
+
+#### Post-Install File Structure
+
+Assuming `-InstallDir "D:\clashtui"`:
+
+```
+D:\clashtui\
+├── bin
+│   └── clashtui.exe
+├── mihomo
+│   ├── config
+│   │   └── config.yaml             # Core config (managed by clashtui)
+│   └── mihomo.exe -> C:\bin\mihomo.exe  # symlink or direct copy
+├── sing-box
+    ├── config
+    │   └── config.json             # Core config (managed by clashtui)
+    └── sing-box.exe -> C:\bin\sing-box.exe
+```
+
+#### Service Registration
+
+The script registers Windows Services via clashtui's own `clashtui service install` subcommand, which uses the `windows-service` crate to call the SCM API — no external tools required.

--- a/docs/clashtui_feature_design_zh.md
+++ b/docs/clashtui_feature_design_zh.md
@@ -54,15 +54,15 @@ ClashTui Core 的文件结构设计 (e.g. `/opt/clashtui`):
 
 ClashTui 支持多种服务管理器，在编译时根据平台自动选择默认值:
 
-| Controller | 平台          | bin_name    | 说明                        |
-|------------|---------------|-------------|----------------------------|
-| Systemd    | Linux (默认)   | `systemctl` | systemd 服务管理             |
-| OpenRc     | Linux (可选)   | `rc-service`| OpenRC 服务管理              |
-| Nssm       | Windows (默认) | `nssm`      | Windows 服务管理             |
-| Launchd    | macOS (默认)   | `launchctl` | launchd 服务管理             |
+| Controller      | 平台          | 实现方式                      | 说明                        |
+|-----------------|---------------|------------------------------|----------------------------|
+| Systemd         | Linux (默认)   | `systemctl` CLI              | systemd 服务管理             |
+| OpenRc          | Linux (可选)   | `rc-service` CLI             | OpenRC 服务管理              |
+| WindowsService  | Windows (默认) | `windows-service` Rust crate | 直接调 Windows SCM API       |
+| Launchd         | macOS (默认)   | `launchctl` CLI              | launchd 服务管理             |
 
 各平台编译时默认:
-- `cfg!(windows)` → Nssm
+- `cfg!(windows)` → WindowsService
 - `cfg!(target_os = "macos")` → Launchd
 - 其他 → Systemd
 
@@ -970,3 +970,270 @@ macOS 与 Linux 统一使用 Unix 组权限管理 Core 文件:
 </dict>
 </plist>
 ```
+
+## Support Windows
+
+### Windows Core 文件结构
+
+ClashTui Core 的文件结构设计 (System mode, e.g. `C:\Program Files\clashtui`):
+
+```
+.
+├── bin
+│   └── clashtui.exe
+├── mihomo
+│   ├── config                          # Core Config Dir
+│   │   └── config.yaml                 # Core Config Path
+│   └── mihomo.exe -> <mihomo.exe bin path> # 或直接放置 .exe
+└── sing-box
+    ├── config                          # Core Config Dir
+    │   └── config.json                 # Core Config Path
+    └── sing-box.exe -> <sing-box bin path>
+```
+
+User mode 的默认路径是 `%LOCALAPPDATA%\clashtui` (e.g. `C:\Users\<User>\AppData\Local\clashtui`)。
+
+ClashTui 的配置文件结构同 Linux/macOS, 存放在 `%APPDATA%\clashtui` (e.g. `C:\Users\<User>\AppData\Roaming\clashtui`).
+
+和 Linux/macOS 类似, Windows 也可使用 symlink 指向二进制路径 (`mklink` / `mklink /D`), 但需要 Administrator 权限。如果用户没有管理员权限, 可以直接放置 `.exe` 文件。
+
+### Core services 管理 (Windows Service API)
+
+Windows 使用 Rust 的 [`windows-service`](https://crates.io/crates/windows-service) crate 直接调用 Windows SCM (Service Control Manager) API 管理服务，无需依赖外部工具 (sc.exe / WinSW / NSSM)。Clash Verge Rev 和 FlClash 都采用相同方式。
+
+#### systemd vs launchd vs Windows SCM 对比
+
+| 操作            | Linux (systemd)                          | macOS (launchd)                               | Windows (SCM API)                                      |
+|-----------------|------------------------------------------|-----------------------------------------------|--------------------------------------------------------|
+| **User Mode**   |                                          |                                               |                                                        |
+| 安装服务        | `systemctl --user link <unit>`           | (plist 写入 `~/Library/LaunchAgents/` 即安装)   | `ServiceManager::create_service()`                     |
+| 卸载服务        | `systemctl --user disable <name>`        | (删除 plist + `launchctl bootout`)              | `service.stop()` → `service.delete()`                  |
+| 启动服务        | `systemctl --user start <name>`          | `launchctl bootstrap gui/$UID <plist>`         | `service.start()`                                      |
+| 停止服务        | `systemctl --user stop <name>`           | `launchctl bootout gui/$UID/<name>`            | `service.stop()`                                       |
+| 查看状态        | `systemctl --user is-active <name>`      | `launchctl print gui/$UID/<name>`              | `service.query_status()` → `ServiceState`              |
+| 崩溃重启        | `Restart=always` (unit file)             | `KeepAlive=true` (plist)                       | `SERVICE_CONFIG_FAILURE_ACTIONS` (通过 SCM API 配置)     |
+| **System Mode** |                                          |                                               |                                                        |
+| 安装服务        | `sudo systemctl link <unit>`             | `sudo launchctl bootstrap system <plist>`      | `ServiceManager::create_service()` (需 Administrator)   |
+| 卸载服务        | `sudo systemctl disable <name>`          | `sudo launchctl bootout system/<name>`         | `stop()` → `delete()`  (需 Administrator)               |
+| 启动服务        | `sudo systemctl start <name>`            | `sudo launchctl bootstrap system <plist>`      | `service.start()` (需 Administrator)                    |
+| 停止服务        | `sudo systemctl stop <name>`             | `sudo launchctl bootout system/<name>`         | `service.stop()` (需 Administrator)                     |
+| 查看状态        | `systemctl is-active <name>`             | `sudo launchctl print system/<name>`           | `service.query_status()`                                |
+| TUN 权限        | `setcap` (Linux capabilities)            | root 运行 (无 setcap)                           | Administrator 运行即可 (LocalSystem 默认)                |
+
+关键差异:
+- **零外部依赖**: `windows-service` crate 直接调用 Windows SCM API，无需用户安装任何第三方工具。SCM API 是 Windows 操作系统的核心组件。
+- **类型安全**: 通过 Rust crate 的强类型 API (`ServiceState`, `ServiceType`, `ServiceStartType`) 管理服务，避免 CLI 字符串解析错误。
+- **崩溃重启**: 通过 SCM API 的 `ChangeServiceConfig2W` + `SERVICE_CONFIG_FAILURE_ACTIONS` 配置。`windows-service` crate 目前不直接暴露此接口，需通过 `windows` crate 补充调用，或安装后使用 `sc failure` 配置。
+
+#### 安装命令示例
+
+clashtui 直接调用 SCM API (无需外部命令):
+
+```rust
+// 伪代码示意
+use windows_service::service_manager::{ServiceManager, ServiceManagerAccess};
+
+let manager = ServiceManager::local_computer(None, ServiceManagerAccess::CREATE_SERVICE)?;
+let service = manager.create_service(
+    &ServiceInfo {
+        name: "clashtui_mihomo".into(),
+        display_name: "ClashTui Mihomo".into(),
+        service_type: ServiceType::OWN_PROCESS,
+        start_type: ServiceStartType::AutoStart,
+        error_control: ServiceErrorControl::Normal,
+        executable_path: r"C:\Program Files\clashtui\mihomo\mihomo.exe",
+        launch_arguments: vec![r#"-d "C:\Program Files\clashtui\mihomo\config""#.into()],
+        dependencies: vec![],
+        account_name: None, // LocalSystem
+        account_password: None,
+    },
+    ServiceAccess::START | ServiceAccess::STOP,
+)?;
+```
+
+#### CoreSrvCtl 新增操作
+
+Windows 命令行不方便, 所以 CoreSrvCtl tab 在 Windows 上额外提供以下操作:
+
+**1. Install Srv (安装服务)**
+
+- 通过 `windows-service` crate 调用 SCM API: `ServiceManager::create_service()`
+- service type: `OWN_PROCESS`, start type: `AutoStart`, account: `LocalSystem` (Administrator 权限)
+- `executable_path` = `bin_path`, `launch_arguments` 根据 CoreType 生成
+- 安装后服务状态变为 `installed`
+- 可选: 安装后通过 `sc failure` 配置崩溃重启策略 (SCM API 的 failure actions 配置较底层)
+
+**2. Uninstall Srv (卸载服务)**
+
+- 如果服务正在运行, 先 `service.stop()`
+- 再 `service.delete()` 卸载服务
+- 卸载后服务状态变为 `uninstalled`
+
+**3. Toggle System Proxy (切换系统代理)**
+
+参考 clashtui v0.2.3 的实现, 通过修改 Windows 注册表实现系统代理的开关:
+
+| 接口                  | 操作                                                                |
+|-----------------------|--------------------------------------------------------------------|
+| 检查系统代理状态       | 读取 `HKCU\Software\Microsoft\Windows\CurrentVersion\Internet Settings\ProxyEnable` (REG_DWORD): `0` = disabled, `1` = enabled |
+| Enable system proxy   | `ProxyEnable` → `1`; `ProxyServer` → `127.0.0.1:<port>`; `ProxyOverride` → `<-loopback>`; 广播 `WM_SETTINGCHANGE` |
+| Disable system proxy  | `ProxyEnable` → `0`; 广播 `WM_SETTINGCHANGE`                        |
+
+代理端口从 core 的 mixed 端口获取 (通常是 `7890`), 通过 REST API `GET /configs` 读取 mixed inbound 的 `listen_port`。
+
+实现方式: 通过 `winreg` crate 直接操作注册表, 或调用 `reg.exe` 命令行 (推荐 `winreg` crate 以获得更好的错误处理)。修改注册表后需调用 `SendMessageTimeoutW(HWND_BROADCAST, WM_SETTINGCHANGE, ...)` 通知系统刷新代理设置。
+
+#### CoreSrvCtl 操作列表 (Windows)
+
+CoreSrvCtl tab 的操作列表:
+
+| 操作             | 说明                                           |
+|------------------|------------------------------------------------|
+| Stop Service     | 停止当前 core 的 service                       |
+| Start Service    | 启动当前 core 的 service                       |
+| Install Srv      | 安装当前 core 为 Windows Service (SCM API create_service) |
+| Uninstall Srv    | 卸载当前 core 的 Windows Service (先 stop 再 delete) |
+| Toggle SysProxy  | 切换系统代理 (enable/disable)                   |
+| Switch Core      | 切换到另一个 core (mihomo ↔ sing-box)           |
+| Stop All         | 停止所有 core services                          |
+
+#### 服务状态
+
+| 状态           | 含义                                |
+|----------------|-------------------------------------|
+| `active`       | 服务正在运行                         |
+| `inactive`     | 服务已安装但未运行                    |
+| `installed`    | Windows Service 已注册 (但未启动)        |
+| `uninstalled`  | 未找到 Windows Service (需要 Install)    |
+| `?`            | 无法确定状态 (如权限不足)         |
+
+状态检测优先级:
+1. 通过 SCM API `service.query_status()` 获取 `ServiceState`
+2. `Running` → `"active"`, `Stopped` → `"inactive"`
+3. 服务未注册 (ERROR_SERVICE_DOES_NOT_EXIST) → `"uninstalled"`
+
+### 文件权限
+
+Windows 使用 NTFS ACL (Access Control List) 管理文件权限, 与 Unix 模式位完全不同。
+
+**Windows 上的策略:**
+- `check_file_permissions()` → 始终返回 `true` (权限始终视为 OK)
+- `repair_file_permissions()` → 始终返回 `Ok("Permissions OK on Windows")` (无需修复)
+- `correct_cap_for_tun()` → 始终返回 `Ok("No setcap on Windows")` (TUN 功能由 core 自行管理)
+- `check_startup_perms()` → 空操作 (跳过权限检查)
+
+原因: Windows 的权限模型基于用户/组 ACL, 不存在 Unix 的 group sticky bit、mode bits 等概念。Core 文件以 Administrator 运行即可获得足够权限, 普通用户的 TUI 工具只需要读写 `%APPDATA%\clashtui` 配置目录 (用户默认有权限)。
+
+### CoreSrvCtl tab 的 Windows 适配
+
+#### 现状 — 当前 CoreSrvCtl 操作
+
+```rust
+enum SrvCtlOp {
+    Stop,        // "Stop Service"
+    Restart,     // "Start Service"
+    SwitchCore,  // "Switch Core"
+    StopAll,     // "Stop All Services"
+}
+```
+
+#### Windows 扩展
+
+在 Windows 上, `ServiceController::default()` 返回 `WindowsService` 时, 额外增加以下操作:
+
+```rust
+#[cfg(windows)]
+SrvCtlOp::Install,       // "Install Service" — SCM API create_service
+#[cfg(windows)]
+SrvCtlOp::Uninstall,     // "Uninstall Service" — stop + delete
+#[cfg(windows)]
+SrvCtlOp::ToggleSysProxy, // "Toggle System Proxy" — 读写注册表
+```
+
+**Install** 执行逻辑:
+1. 通过 `windows-service` crate 调用 `ServiceManager::create_service()`
+2. service type: `OWN_PROCESS`, account: `LocalSystem`, start: `AutoStart`
+3. `executable_path` = `bin_path`, `launch_arguments` 根据 CoreType 生成
+4. 更新状态为 `installed`
+
+**Uninstall** 执行逻辑:
+1. 打开 service, 如果 running 则先 `service.stop()`
+2. 再 `service.delete()`
+3. 更新状态为 `uninstalled`
+
+**Toggle System Proxy** 执行逻辑:
+1. 读取当前 `ProxyEnable` 注册表值
+2. 如果当前 disabled → enable: 设置 `ProxyEnable=1`, `ProxyServer=127.0.0.1:<port>`, `ProxyOverride=<-loopback>`, 广播 `WM_SETTINGCHANGE`
+3. 如果当前 enabled → disable: 设置 `ProxyEnable=0`, 广播 `WM_SETTINGCHANGE`
+4. 混合端口通过 REST API 读取 `GET /configs` 的 mixed inbound 配置
+
+#### 状态查询适配
+
+当前 srvctl 的状态查询 hardcode `systemctl is-active` 用于非 Launchd 的情况。需适配为:
+
+```rust
+match ServiceController::default() {
+    ServiceController::Launchd => launchd_status(...),
+    ServiceController::WindowsService => windows_service_status(...), // 新增
+    _ => systemd_status(...),
+}
+```
+
+`windows_service_status()` 实现:
+1. 通过 `windows-service` crate 打开 service → `service.query_status()`
+2. 解析 `ServiceState`:
+   - `Running` → `"active"`
+   - `Stopped` / `Paused` 等 → `"inactive"`
+   - `ERROR_SERVICE_DOES_NOT_EXIST` → `"uninstalled"`
+
+### Install Script
+
+为了降低 Windows 用户的部署门槛, 提供一个 PowerShell 安装脚本 (`install.ps1`) 完成以下操作:
+
+#### 功能
+
+1. **选择安装目录**: 默认 `C:\Program Files\clashtui`, 用户可通过参数指定其他位置 (e.g. `D:\clashtui`)
+2. **创建目录结构**: 自动创建 `mihomo/config/`, `sing-box/config/` 等子目录
+3. **复制文件**:
+   - 复制或提示用户放置 `mihomo.exe` / `sing-box.exe` 到对应 core 目录
+   - 复制 `clashtui.exe` 到 `bin/`
+4. **注册 Windows Service**: clashtui 通过 `windows-service` crate 的 SCM API 注册两个 core services (无需外部工具)
+6. **生成 config.yaml 模板**: 自动填充 `bin_path` 和 `config_dir` 为用户选择的安装目录
+
+#### 使用方式
+
+```powershell
+# 默认安装到 C:\Program Files\clashtui
+.\install.ps1
+
+# 安装到自定义目录
+.\install.ps1 -InstallDir "D:\MyTools\clashtui"
+```
+
+#### Windows 平台的额外参数
+
+| 参数           | 默认值                         | 说明                                      |
+|----------------|-------------------------------|------------------------------------------|
+| `-InstallDir`   | `C:\Program Files\clashtui`   | 安装根目录                                 |
+
+#### 安装后的文件结构
+
+假设 `-InstallDir "D:\clashtui"`:
+
+```
+D:\clashtui\
+├── bin
+│   └── clashtui.exe
+├── mihomo
+│   ├── config
+│   │   └── config.yaml             # Core config (由 clashtui 管理)
+│   └── mihomo.exe -> C:\bin\mihomo.exe  # symlink 或直接放置
+└── sing-box
+    ├── config
+    │   └── config.json             # Core config (由 clashtui 管理)
+    └── sing-box.exe -> C:\bin\sing-box.exe
+```
+
+#### Service 注册
+
+脚本通过 clashtui 自身的 `clashtui service install` 子命令注册 Windows Service, 底层使用 `windows-service` crate 调用 SCM API, 无需外部工具。


### PR DESCRIPTION
## Summary

Add comprehensive Windows support design documentation in both English and Chinese, outlining the architecture for Windows platform support — service management via SCM API, file structure, permissions strategy, CoreSrvCtl tab adaptations, and install script design.

## Changes

### ServiceController Update
- Replaced Nssm with WindowsService in the controller table — Windows will use the windows-service Rust crate to call the SCM API directly, eliminating external tool dependencies (no sc.exe / WinSW / NSSM)

### New Support Windows Section
- Core file structure (system mode: C:\Program Files\clashtui, user mode: %LOCALAPPDATA%\clashtui)
- Service management via Windows SCM API with full comparison table (systemd vs launchd vs Windows SCM)
- 3 new Windows-only CoreSrvCtl operations: Install Srv, Uninstall Srv, Toggle SysProxy
- Service state model: active / inactive / installed / uninstalled
- Registry-based system proxy toggle (ProxyEnable, ProxyServer, ProxyOverride, WM_SETTINGCHANGE broadcast)
- File permissions strategy (always OK on Windows, no Unix-style checks)
- PowerShell install.ps1 design with -InstallDir parameter

## Files Changed
- docs/clashtui_feature_design_en.md (+281)
- docs/clashtui_feature_design_zh.md (+274 / -7)
- Total: +555 / -7