### PR TITLE
fix: Remove auto-start from macOS launchd services and fix CI runner labels

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -35,14 +35,14 @@ jobs:
             cache-suffix: linux-arm64
             run-test: false
 
-          - os: macos-13
+          - os: macos-latest
             target: x86_64-apple-darwin
             artifact-name: macOS_x86_64_Build
             binary-name: clashtui-darwin-amd64-debug
             cache-suffix: macos-x86_64
             run-test: false
 
-          - os: macos-14
+          - os: macos-latest
             target: aarch64-apple-darwin
             artifact-name: macOS_aarch64_Build
             binary-name: clashtui-darwin-arm64-debug

--- a/install
+++ b/install
@@ -54,7 +54,7 @@ resolve_paths() {
     SERVICE_IS_USER=true
     if $IS_MACOS; then
       UNIT_DIR="$HOME/Library/LaunchAgents"
-      SERVICE_LOAD_CMD="launchctl load -w"
+      SERVICE_LOAD_CMD=""
       SERVICE_UNLOAD_CMD="launchctl unload"
       SERVICE_ENABLE_CMD="launchctl load -w"
       LAUNCHD_DOMAIN="gui/\$(id -u)"
@@ -72,7 +72,7 @@ resolve_paths() {
       INSTALL_DIR="/usr/local/opt/clashtui"
       UNIT_DIR="/Library/LaunchDaemons"
       SUDO="sudo"
-      SERVICE_LOAD_CMD="sudo launchctl load -w"
+      SERVICE_LOAD_CMD=""
       SERVICE_UNLOAD_CMD="sudo launchctl unload"
       SERVICE_ENABLE_CMD="sudo launchctl load -w"
       LAUNCHD_DOMAIN="system"
@@ -457,8 +457,9 @@ create_mihomo_unit() {
 </plist>
 EOF
     log_info "Created launchd plist: $plist_path"
-    # Load and start the service
-    $SERVICE_LOAD_CMD "$plist_path"
+    if [ -n "$SERVICE_LOAD_CMD" ]; then
+      $SERVICE_LOAD_CMD "$plist_path"
+    fi
   else
     # ── Linux: systemd unit ──
     log_info "Creating mihomo systemd unit..."
@@ -563,7 +564,9 @@ create_singbox_unit() {
 </plist>
 EOF
     log_info "Created launchd plist: $plist_path"
-    $SERVICE_LOAD_CMD "$plist_path"
+    if [ -n "$SERVICE_LOAD_CMD" ]; then
+      $SERVICE_LOAD_CMD "$plist_path"
+    fi
   else
     # ── Linux: systemd unit ──
     log_info "Creating sing-box systemd unit..."
@@ -1079,17 +1082,31 @@ main() {
 
   if $IS_USER; then
     if $IS_MACOS; then
-      log_info "User mode: services are loaded via launchd (~/Library/LaunchAgents)"
+      log_info "User mode: plist files created in ~/Library/LaunchAgents/"
+      log_info "Services are NOT started automatically. Use these commands:"
+      log_info "  Start now:         launchctl load ~/Library/LaunchAgents/clashtui_mihomo.plist"
+      log_info "  Start + autostart: launchctl load -w ~/Library/LaunchAgents/clashtui_mihomo.plist"
+      log_info "  Stop + disable:    launchctl unload ~/Library/LaunchAgents/clashtui_mihomo.plist"
       log_warn "Services will stop when you log out. To keep them running, keep the session active."
     else
-      log_warn "User mode: services run under systemctl --user"
+      log_info "User mode: unit files created in ~/.config/systemd/user/"
+      log_info "Services are NOT started automatically. Use these commands:"
+      log_info "  Start now:         systemctl --user start clashtui_mihomo"
+      log_info "  Start + autostart: systemctl --user enable --now clashtui_mihomo"
       log_warn "To keep services running after logout, run: loginctl enable-linger"
     fi
   else
     if $IS_MACOS; then
-      log_info "System mode: services are loaded via launchd (/Library/LaunchDaemons)"
+      log_info "System mode: plist files created in /Library/LaunchDaemons/"
+      log_info "Services are NOT started automatically. Use these commands:"
+      log_info "  Start now:         sudo launchctl load /Library/LaunchDaemons/clashtui_mihomo.plist"
+      log_info "  Start + autostart: sudo launchctl load -w /Library/LaunchDaemons/clashtui_mihomo.plist"
+      log_info "  Stop + disable:    sudo launchctl unload /Library/LaunchDaemons/clashtui_mihomo.plist"
     else
-      log_warn "Please log out and log back in for the group file permissions to take effect"
+      log_info "System mode: unit files created in /usr/lib/systemd/system/"
+      log_info "Services are NOT started automatically. Use these commands:"
+      log_info "  Start now:         sudo systemctl start clashtui_mihomo"
+      log_info "  Start + autostart: sudo systemctl enable --now clashtui_mihomo"
     fi
   fi
 }

--- a/src/functions/command.rs
+++ b/src/functions/command.rs
@@ -191,12 +191,12 @@ fn launchd_operation(
     };
 
     match op {
-        "start" => do_exec(vec!["load", "-w", &plist]),
+        "start" => do_exec(vec!["load", &plist]),
         "stop" => do_exec(vec!["unload", &plist]),
         "restart" | "reload" => {
             // Best-effort unload, then load
             let _ = do_exec(vec!["unload", &plist]);
-            do_exec(vec!["load", "-w", &plist])
+            do_exec(vec!["load", &plist])
         }
         _ => Err(anyhow::anyhow!("Unknown launchd operation: {op}")),
     }


### PR DESCRIPTION
## Summary

Removes the auto-start (`-w`) flag from macOS launchd start/restart operations and the install script, so services are not automatically persisted across reboots without explicit user consent. Also fixes the GitHub Actions `pr.yml` macOS runner to use `macos-latest` instead of version-specific labels.

## Problem

1. In #64, macOS launchd operations used `launchctl load -w` by default for start and restart. The `-w` flag both loads the service and permanently enables it (auto-start on boot) — equivalent to systemd's `enable --now`. This can be unexpected behavior, especially during install where services were auto-started and auto-enabled without prompting the user.

2. `pr.yml` used version-specific macOS runner labels (`macos-13`, `macos-14`) which will break when GitHub deprecates those runner images.

## Changes

### `src/functions/command.rs`
- `launchd_operation("start", ...)` — removed `-w` flag, now uses `launchctl load` (start now, no auto-enable)
- `launchd_operation("restart", ...)` — removed `-w` flag, now uses `launchctl load` after unload

### `install` Script
- `SERVICE_LOAD_CMD` set to empty string on macOS (was `launchctl load -w`)
- Guarded plist loading behind `[ -n "$SERVICE_LOAD_CMD" ]` check
- Added explicit post-install instructions for both macOS and Linux showing how to start now vs start with autostart

### `.github/workflows/pr.yml`
- Changed macOS matrix entries from `macos-13` / `macos-14` to `macos-latest` for future-proofing

## Files Changed
- `install` (+26 / -9)
- `src/functions/command.rs` (+2 / -2)
- `.github/workflows/pr.yml` (+2 / -2)
- Total: +30 / -13
