### PR TITLE
Feature/windows supporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,6 +258,8 @@ dependencies = [
  "tokio",
  "tungstenite",
  "unicode-width",
+ "windows",
+ "winreg",
 ]
 
 [[package]]
@@ -1223,7 +1225,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2472,10 +2474,112 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-link 0.1.3",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.1.3",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core",
+ "windows-link 0.1.3",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core",
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
+]
 
 [[package]]
 name = "windows-sys"
@@ -2501,7 +2605,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2518,6 +2622,15 @@ dependencies = [
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
  "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -2567,6 +2680,16 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winreg"
+version = "0.55.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,8 @@ winreg = "0.55"
 windows = { version = "0.61", features = [
     "Win32_UI_WindowsAndMessaging",
     "Win32_Foundation",
+    "Win32_Security",
+    "Win32_System_Threading",
 ] }
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,13 +59,21 @@ ratatui = { version = "0.30.0", features = [
     "crossterm",
 ], default-features = false, optional = true }
 futures-lite = { version = "2.6.0", default-features = false, optional = true }
-signal-hook-tokio = { version = "0", features = ["futures-v0_3"], optional = true }
+
 unicode-width = { version = "0.2.0", default-features = false }
 nix = { version = "0", features = ["user", "fs"] }
 tungstenite = { version = "0.29", default-features = false, features = ["handshake", "url"], optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+signal-hook-tokio = { version = "0", features = ["futures-v0_3"], optional = true }
+
+[target.'cfg(windows)'.dependencies]
+winreg = "0.55"
+windows = { version = "0.61", features = [
+    "Win32_UI_WindowsAndMessaging",
+    "Win32_Foundation",
+] }
 
 [features]
 customized-theme = ["tui", "ratatui/serde"]

--- a/docs/clashtui_feature_design_zh.md
+++ b/docs/clashtui_feature_design_zh.md
@@ -1003,9 +1003,11 @@ ClashTui 的配置文件结构同 Linux/macOS, 存放在 `%APPDATA%\clashtui` (e
 
 和 Linux/macOS 类似, Windows 也可使用 symlink 指向二进制路径 (`mklink` / `mklink /D`), 但需要 Administrator 权限。如果用户没有管理员权限, 可以直接放置 `.exe` 文件。
 
-### 文件权限
+### 文件权限和服务权限
 
 ClashTui core 的文件不要安装在 `C:/Program Files` 和  `C:/Program Files (x86)` 等, 以避免一些文件权限问题。
+
+需要有自动提权的机制, 因为启动需要 TUN 的 Core Service 时, 需要管理员权限。
 
 ### Core services 管理 (nssm)
 
@@ -1122,3 +1124,7 @@ CoreSrvCtl tab 的操作列表:
 ```
 
 **因为 ClashTui 已经支持 install core service 了, 所以 install.ps1 不需要安装 Core service。**
+
+### Windows 文件路径的格式
+
+统一使用 `D:/Foo/Bar` 的格式, 而不使用 `D:\\Foo\\Bar` 的形式 (觉得不好看, 和不方便处理)。

--- a/install.ps1
+++ b/install.ps1
@@ -545,11 +545,8 @@ function Invoke-OptionalDownloads {
         $response = Read-Host "Do you want to download templates for sing-box? (y/N)"
         if ($response -eq "y" -or $response -eq "Y") {
             Write-Info "Downloading sing-box templates..."
-            Copy-Contrib "templates/sing-box/v1.12-common_tpl.json" (Join-Path $SINGBOX_USER_CONFIG_DIR "templates/v1.12-common_tpl.json")
-            Copy-Contrib "templates/sing-box/v1.12-tun_fakeip_bypass_dnsleak.json" (Join-Path $SINGBOX_USER_CONFIG_DIR "templates/v1.12-tun_fakeip_bypass_dnsleak.json")
-            Copy-Contrib "templates/sing-box/v1.12-tun_fakeip_bypass_no_dnsleak.json" (Join-Path $SINGBOX_USER_CONFIG_DIR "templates/v1.12-tun_fakeip_bypass_no_dnsleak.json")
-            Copy-Contrib "templates/sing-box/v1.12-tun_ipv4_ipv6.json" (Join-Path $SINGBOX_USER_CONFIG_DIR "templates/v1.12-tun_ipv4_ipv6.json")
-            Copy-Contrib "templates/sing-box/v1.12-tun_ipv4_only.json" (Join-Path $SINGBOX_USER_CONFIG_DIR "templates/v1.12-tun_ipv4_only.json")
+            Copy-Contrib "templates/sing-box/v1.12-tun_common_tpl.json" (Join-Path $SINGBOX_USER_CONFIG_DIR "templates/v1.12-tun_common_tpl.json")
+            Copy-Contrib "templates/sing-box/v1.12-tun_bypass.json" (Join-Path $SINGBOX_USER_CONFIG_DIR "templates/v1.12-tun_bypass.json")
         }
     }
 }

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,605 @@
+<#
+.SYNOPSIS
+    ClashTui install script for Windows
+.DESCRIPTION
+    Downloads and installs clashtui binaries, core binaries (mihomo, sing-box),
+    and default configuration files on Windows. Does NOT manage Windows services
+    (use ClashTui's CoreSrvCtl for that).
+.PARAMETER InstallDir
+    Installation directory for binaries (default: D:\ClashTui)
+.PARAMETER Core
+    Core type to install: mihomo, sing-box, or all (default: all)
+.PARAMETER Repo
+    GitHub repository for clashtui and contrib (default: JohanChane/clashtui)
+.PARAMETER Branch
+    Branch for contrib resources (default: main)
+.EXAMPLE
+    .\install.ps1
+    .\install.ps1 -InstallDir "D:\MyTools\ClashTui"
+    .\install.ps1 -Core mihomo
+#>
+
+param(
+    [string]$InstallDir = "D:\ClashTui",
+    [ValidateSet("mihomo", "sing-box", "all")]
+    [string]$Core = "all",
+    [string]$Repo = "JohanChane/clashtui",
+    [string]$Branch = "main"
+)
+
+$ErrorActionPreference = "Stop"
+
+# --- Constants ---
+$MIHOMO_UPSTREAM = "MetaCubeX/mihomo"
+$SINGBOX_UPSTREAM = "SagerNet/sing-box"
+
+# --- Logging ---
+function Write-Info {
+    param([string]$Message)
+    Write-Host "[INFO] $Message" -ForegroundColor Green
+}
+
+function Write-Warn {
+    param([string]$Message)
+    Write-Host "[WARN] $Message" -ForegroundColor Yellow
+}
+
+function Write-ErrorLog {
+    param([string]$Message)
+    Write-Host "[ERROR] $Message" -ForegroundColor Red
+}
+
+# --- Validation ---
+function Test-ValidInstallDir {
+    param([string]$Path)
+
+    if ($Path -match '\s') {
+        Write-ErrorLog "InstallDir must not contain spaces: $Path"
+        exit 1
+    }
+
+    # Normalize path for comparison
+    $normalized = (Resolve-Path $Path -ErrorAction SilentlyContinue).Path
+    if (-not $normalized) { $normalized = $Path }
+
+    $restricted = @(
+        [System.Environment]::GetFolderPath('ProgramFiles'),
+        [System.Environment]::GetFolderPath('ProgramFilesX86')
+    )
+
+    foreach ($r in $restricted) {
+        if ($normalized -and $normalized.StartsWith($r, [StringComparison]::OrdinalIgnoreCase)) {
+            Write-ErrorLog "InstallDir must not be under a restricted directory: $r"
+            Write-ErrorLog "Use a non-system directory like D:\ClashTui"
+            exit 1
+        }
+    }
+
+    # Check write permission
+    try {
+        $parent = Split-Path $Path -Parent
+        if (-not (Test-Path $parent)) {
+            New-Item -ItemType Directory -Path $parent -Force -ErrorAction Stop | Out-Null
+        }
+        $testFile = Join-Path $Path ".clashtui_write_test"
+        New-Item -ItemType Directory -Path $Path -Force -ErrorAction Stop | Out-Null
+        [System.IO.File]::WriteAllText($testFile, "test")
+        Remove-Item $testFile -Force -ErrorAction SilentlyContinue
+    } catch {
+        Write-ErrorLog "Cannot write to $Path. Run as Administrator or choose a different directory."
+        exit 1
+    }
+}
+
+# --- Detection ---
+function Get-Architecture {
+    $arch = [System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture
+    switch ($arch) {
+        'X64'  { return "amd64" }
+        'Arm64' { return "arm64" }
+        default { return "unsupported" }
+    }
+}
+
+function Get-OS {
+    if ([System.Environment]::OSVersion.Platform -eq [System.PlatformID]::Win32NT) {
+        return "windows"
+    }
+    return "unsupported"
+}
+
+# --- Resolve paths ---
+function Resolve-Paths {
+    $script:INSTALL_DIR = $InstallDir
+    $script:INSTALL_DIR_MIHOMO = Join-Path $InstallDir "mihomo"
+    $script:INSTALL_DIR_SINGBOX = Join-Path $InstallDir "sing-box"
+    $script:MIHOMO_CONFIG_DIR = Join-Path $INSTALL_DIR_MIHOMO "config"
+    $script:SINGBOX_CONFIG_DIR = Join-Path $INSTALL_DIR_SINGBOX "config"
+    $script:INSTALL_BIN = Join-Path $InstallDir "bin"
+
+    $script:CLASHTUI_CONFIG_DIR = Join-Path $env:APPDATA "clashtui"
+    $script:MIHOMO_USER_CONFIG_DIR = Join-Path $CLASHTUI_CONFIG_DIR "mihomo"
+    $script:SINGBOX_USER_CONFIG_DIR = Join-Path $CLASHTUI_CONFIG_DIR "sing-box"
+
+    $script:SCRIPT_DIR = Split-Path $MyInvocation.ScriptName -Parent
+    $script:CONTRIB_SOURCE = if (Test-Path (Join-Path $SCRIPT_DIR "contrib")) { "local" } else { "remote" }
+    $script:CONTRIB_DIR = if ($CONTRIB_SOURCE -eq "local") { Join-Path $SCRIPT_DIR "contrib" } else { $null }
+
+    $script:CONTRIB_URL_PREFIX = "https://raw.githubusercontent.com/${Repo}/refs/heads/${Branch}/contrib"
+}
+
+# --- Helper: copy contrib (local or remote) ---
+function Copy-Contrib {
+    param(
+        [string]$RelativePath,
+        [string]$Destination
+    )
+
+    if ($CONTRIB_SOURCE -eq "local") {
+        $src = Join-Path $CONTRIB_DIR $RelativePath
+        if (Test-Path $src) {
+            Copy-Item $src $Destination -Force
+            return
+        }
+        Write-Warn "Local file not found: $src, falling back to remote"
+    }
+
+    $remoteUrl = "${CONTRIB_URL_PREFIX}/${RelativePath}"
+    try {
+        Invoke-WebRequest -Uri $remoteUrl -OutFile $Destination -UseBasicParsing
+    } catch {
+        Write-ErrorLog "Failed to download: $remoteUrl"
+        throw
+    }
+}
+
+# --- Backup ---
+function Backup-File {
+    param([string]$Path)
+    if (-not (Test-Path $Path)) { return }
+    $i = 1
+    while (Test-Path "${Path}_$i") { $i++ }
+    Move-Item $Path "${Path}_$i" -Force
+    Write-Info "Backed up: $Path -> ${Path}_$i"
+}
+
+function Get-CommandPath {
+    param([string]$Name)
+    $cmd = Get-Command $Name -ErrorAction SilentlyContinue
+    if ($cmd) { return $cmd.Source }
+    return $null
+}
+
+# --- Binary download ---
+function Get-LatestGithubRelease {
+    param([string]$Repo)
+    $url = "https://api.github.com/repos/${Repo}/releases/latest"
+    $response = Invoke-RestMethod -Uri $url -UseBasicParsing
+    return $response
+}
+
+function Find-AssetUrl {
+    param(
+        [object]$Release,
+        [string[]]$NamePatterns
+    )
+    foreach ($pattern in $NamePatterns) {
+        foreach ($asset in $Release.assets) {
+            if ($asset.name -like $pattern) {
+                return $asset.browser_download_url
+            }
+        }
+    }
+    return $null
+}
+
+function Install-Mihomo {
+    $destDir = $INSTALL_DIR_MIHOMO
+    $destExe = Join-Path $destDir "mihomo.exe"
+    Write-Info "Installing mihomo..."
+
+    # Already installed at destination — skip
+    if (Test-Path $destExe) {
+        Write-Info "mihomo already exists at $destExe, skipping"
+        return
+    }
+
+    # Found in PATH — link/copy to destination
+    $existing = Get-CommandPath "mihomo.exe"
+    if ($existing) {
+        Write-Info "Found mihomo in PATH: $existing, linking..."
+        New-Item -ItemType Directory -Path $destDir -Force | Out-Null
+        Copy-Item -Path $existing -Destination $destExe -Force
+        Write-Info "Linked mihomo to: $destExe"
+        return
+    }
+
+    # Not found — download
+    $arch = Get-Architecture
+    $os = Get-OS
+
+    if ($arch -eq "unsupported" -or $os -eq "unsupported") {
+        Write-ErrorLog "Unsupported architecture or OS"
+        exit 1
+    }
+
+    $release = Get-LatestGithubRelease $MIHOMO_UPSTREAM
+    $version = $release.tag_name
+    $assetUrl = Find-AssetUrl $release @(
+        "*windows*amd64*compatible*",
+        "*windows*amd64*",
+        "*windows*x86_64*"
+    )
+
+    if (-not $assetUrl) {
+        Write-ErrorLog "Could not find mihomo release asset for Windows amd64"
+        exit 1
+    }
+
+    Write-Info "Detected: OS=$os, Arch=$arch, Version=$version"
+    Write-Info "Downloading: $assetUrl"
+
+    $tempDir = Join-Path $env:TEMP "clashtui_mihomo_$(Get-Random)"
+    New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
+    $zipPath = Join-Path $tempDir "mihomo.zip"
+
+    try {
+        Invoke-WebRequest -Uri $assetUrl -OutFile $zipPath -UseBasicParsing
+        Expand-Archive -Path $zipPath -DestinationPath $tempDir -Force
+
+        $binary = Get-ChildItem -Path $tempDir -Recurse -Name "mihomo.exe" | Select-Object -First 1
+        if (-not $binary) {
+            Write-ErrorLog "Could not find mihomo.exe in the downloaded archive"
+            exit 1
+        }
+        $binaryPath = Join-Path $tempDir $binary
+
+        New-Item -ItemType Directory -Path $destDir -Force | Out-Null
+        Copy-Item $binaryPath $destExe -Force
+        Write-Info "Successfully installed mihomo to: $destExe"
+    } finally {
+        Remove-Item $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Install-SingBox {
+    $destDir = $INSTALL_DIR_SINGBOX
+    $destExe = Join-Path $destDir "sing-box.exe"
+    Write-Info "Installing sing-box..."
+
+    # Already installed at destination — skip
+    if (Test-Path $destExe) {
+        Write-Info "sing-box already exists at $destExe, skipping"
+        return
+    }
+
+    # Found in PATH — link/copy to destination
+    $existing = Get-CommandPath "sing-box.exe"
+    if ($existing) {
+        Write-Info "Found sing-box in PATH: $existing, linking..."
+        New-Item -ItemType Directory -Path $destDir -Force | Out-Null
+        Copy-Item -Path $existing -Destination $destExe -Force
+        Write-Info "Linked sing-box to: $destExe"
+        return
+    }
+
+    # Not found — download
+    $arch = Get-Architecture
+    $os = Get-OS
+
+    if ($arch -eq "unsupported" -or $os -eq "unsupported") {
+        Write-ErrorLog "Unsupported architecture or OS"
+        exit 1
+    }
+
+    $release = Get-LatestGithubRelease $SINGBOX_UPSTREAM
+    $version = $release.tag_name
+    $assetUrl = Find-AssetUrl $release @(
+        "*windows*amd64*",
+        "*windows*x86_64*"
+    )
+
+    if (-not $assetUrl) {
+        Write-ErrorLog "Could not find sing-box release asset for Windows amd64"
+        exit 1
+    }
+
+    Write-Info "Detected: OS=$os, Arch=$arch, Version=$version"
+    Write-Info "Downloading: $assetUrl"
+
+    $tempDir = Join-Path $env:TEMP "clashtui_singbox_$(Get-Random)"
+    New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
+    $zipPath = Join-Path $tempDir "sing-box.zip"
+
+    try {
+        Invoke-WebRequest -Uri $assetUrl -OutFile $zipPath -UseBasicParsing
+        Expand-Archive -Path $zipPath -DestinationPath $tempDir -Force
+
+        $binary = Get-ChildItem -Path $tempDir -Recurse -Name "sing-box.exe" | Select-Object -First 1
+        if (-not $binary) {
+            Write-ErrorLog "Could not find sing-box.exe in the downloaded archive"
+            exit 1
+        }
+        $binaryPath = Join-Path $tempDir $binary
+
+        New-Item -ItemType Directory -Path $destDir -Force | Out-Null
+        Copy-Item $binaryPath $destExe -Force
+        Write-Info "Successfully installed sing-box to: $destExe"
+    } finally {
+        Remove-Item $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Install-ClashTui {
+    param([string]$CoreType)
+    $destDir = $INSTALL_BIN
+    $destExe = Join-Path $destDir "clashtui.exe"
+    Write-Info "Installing clashtui..."
+
+    # Already installed at destination — skip
+    if (Test-Path $destExe) {
+        Write-Info "clashtui already exists at $destExe, skipping"
+        New-ClashTuiConfig $CoreType
+        return
+    }
+
+    # Found in PATH — link/copy to destination
+    $existing = Get-CommandPath "clashtui.exe"
+    if ($existing) {
+        Write-Info "Found clashtui in PATH: $existing, linking..."
+        New-Item -ItemType Directory -Path $destDir -Force | Out-Null
+        Copy-Item -Path $existing -Destination $destExe -Force
+        Write-Info "Linked clashtui to: $destExe"
+        New-ClashTuiConfig $CoreType
+        return
+    }
+
+    # Not found — download
+    $arch = Get-Architecture
+    $os = Get-OS
+
+    if ($arch -eq "unsupported" -or $os -eq "unsupported") {
+        Write-ErrorLog "Unsupported architecture or OS"
+        exit 1
+    }
+
+    $release = Get-LatestGithubRelease $Repo
+    $version = $release.tag_name
+    $assetUrl = Find-AssetUrl $release @("*windows*amd64*", "*windows*x86_64*")
+
+    if (-not $assetUrl) {
+        Write-ErrorLog "Could not find clashtui release asset for Windows amd64"
+        exit 1
+    }
+
+    Write-Info "Detected: OS=$os, Arch=$arch, Version=$version"
+    Write-Info "Downloading: $assetUrl"
+
+    $tempDir = Join-Path $env:TEMP "clashtui_$(Get-Random)"
+    New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
+    $zipPath = Join-Path $tempDir "clashtui.zip"
+
+    try {
+        Invoke-WebRequest -Uri $assetUrl -OutFile $zipPath -UseBasicParsing
+        Expand-Archive -Path $zipPath -DestinationPath $tempDir -Force
+
+        $binary = Get-ChildItem -Path $tempDir -Recurse -Name "clashtui.exe" | Select-Object -First 1
+        if (-not $binary) {
+            Write-ErrorLog "Could not find clashtui.exe in the downloaded archive"
+            exit 1
+        }
+        $binaryPath = Join-Path $tempDir $binary
+
+        New-Item -ItemType Directory -Path $destDir -Force | Out-Null
+        Copy-Item $binaryPath $destExe -Force
+        Write-Info "Successfully installed clashtui to: $destExe"
+    } finally {
+        Remove-Item $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    New-ClashTuiConfig $CoreType
+}
+
+# --- Config generation ---
+function New-ClashTuiConfig {
+    param([string]$CoreType)
+    Write-Info "Creating clashtui config..."
+
+    New-Item -ItemType Directory -Path $CLASHTUI_CONFIG_DIR -Force | Out-Null
+
+    # Copy default configs
+    Copy-Contrib "default_configs/default_keymap.yaml" (Join-Path $CLASHTUI_CONFIG_DIR "default_keymap.yaml")
+    Copy-Contrib "default_configs/default_theme.yaml" (Join-Path $CLASHTUI_CONFIG_DIR "default_theme.yaml")
+    Write-Info "Copied default configs to: $CLASHTUI_CONFIG_DIR"
+
+    # Generate config.yaml
+    $configPath = Join-Path $CLASHTUI_CONFIG_DIR "config.yaml"
+    Backup-File $configPath
+
+    $mihomoBinDir = $INSTALL_DIR_MIHOMO -replace '\\', '\\'
+    $singboxBinDir = $INSTALL_DIR_SINGBOX -replace '\\', '\\'
+    $mihomoCfgDir = $MIHOMO_CONFIG_DIR -replace '\\', '\\'
+    $singboxCfgDir = $SINGBOX_CONFIG_DIR -replace '\\', '\\'
+
+    $configContent = @"
+mihomo:
+  core:
+    config_dir: ${mihomoCfgDir}
+    bin_path: ${mihomoBinDir}\mihomo.exe
+    config_path: ${mihomoCfgDir}\config.yaml
+  core_service:
+    service_name: clashtui_mihomo
+    is_user: false
+singbox:
+  core:
+    bin_path: ${singboxBinDir}\sing-box.exe
+    config_dir: ${singboxCfgDir}
+    config_path: ${singboxCfgDir}\config.json
+  core_service:
+    service_name: clashtui_singbox
+    is_user: false
+timeout:
+extra:
+  edit_cmd:
+  open_dir_cmd:
+"@
+
+    Set-Content -Path $configPath -Value $configContent -Encoding UTF8
+    Write-Info "Config written to: $configPath"
+
+    # Create directories and template_proxy_providers.yaml
+    $tppContent = @'
+# Define proxy-provider subscription URLs here, organized by group.
+# In templates use ${PPG.<group>} to reference all providers in a group,
+# or ${PPG.<group>.<provider>} for a specific one.
+#
+# Format:
+#   <group-name>:
+#     <provider-name>: "<subscription-url>"
+#
+# Clashtui's built-in templates only use the group level
+# (e.g. ${PPG.pvd}, not ${PPG.pvd.pvd0}). Provider names
+# (pvd0, pvd1, ...) are freely defined by the user.
+#
+# Example (following clashtui convention):
+#   pvd:
+#     pvd0: "https://example.com/sub1.yaml"
+#     pvd1: "https://example.com/sub2.yaml"
+'@
+
+    if ($CoreType -eq "mihomo" -or $CoreType -eq "all") {
+        New-Item -ItemType Directory -Path $MIHOMO_USER_CONFIG_DIR -Force | Out-Null
+        New-Item -ItemType Directory -Path (Join-Path $MIHOMO_USER_CONFIG_DIR "profiles") -Force | Out-Null
+        New-Item -ItemType Directory -Path (Join-Path $MIHOMO_USER_CONFIG_DIR "templates") -Force | Out-Null
+
+        $tppPath = Join-Path $MIHOMO_USER_CONFIG_DIR "template_proxy_providers.yaml"
+        if (-not (Test-Path $tppPath)) {
+            Set-Content -Path $tppPath -Value $tppContent -Encoding UTF8
+        }
+    }
+
+    if ($CoreType -eq "sing-box" -or $CoreType -eq "all") {
+        New-Item -ItemType Directory -Path $SINGBOX_USER_CONFIG_DIR -Force | Out-Null
+        New-Item -ItemType Directory -Path (Join-Path $SINGBOX_USER_CONFIG_DIR "profiles") -Force | Out-Null
+        New-Item -ItemType Directory -Path (Join-Path $SINGBOX_USER_CONFIG_DIR "templates") -Force | Out-Null
+
+        $tppPath = Join-Path $SINGBOX_USER_CONFIG_DIR "template_proxy_providers.yaml"
+        if (-not (Test-Path $tppPath)) {
+            Set-Content -Path $tppPath -Value $tppContent -Encoding UTF8
+        }
+    }
+}
+
+# --- Core config creation ---
+function New-CoreConfigs {
+    param([string]$CoreType)
+    Write-Info "Creating core config files..."
+
+    if ($CoreType -eq "mihomo" -or $CoreType -eq "all") {
+        New-Item -ItemType Directory -Path $MIHOMO_CONFIG_DIR -Force | Out-Null
+
+        $cfgSrc = "default_configs/mihomo/core_override_config.yaml"
+        Copy-Contrib $cfgSrc (Join-Path $MIHOMO_CONFIG_DIR "config.yaml")
+        Write-Info "Mihomo core config written to: $MIHOMO_CONFIG_DIR\config.yaml"
+
+        New-Item -ItemType Directory -Path $MIHOMO_USER_CONFIG_DIR -Force | Out-Null
+        Copy-Contrib $cfgSrc (Join-Path $MIHOMO_USER_CONFIG_DIR "core_override_config.yaml")
+        Write-Info "Mihomo core override written to: $MIHOMO_USER_CONFIG_DIR\core_override_config.yaml"
+    }
+
+    if ($CoreType -eq "sing-box" -or $CoreType -eq "all") {
+        New-Item -ItemType Directory -Path $SINGBOX_CONFIG_DIR -Force | Out-Null
+
+        $cfgSrc = "default_configs/sing-box/core_override_config.json"
+        Copy-Contrib $cfgSrc (Join-Path $SINGBOX_CONFIG_DIR "config.json")
+        Write-Info "Sing-box core config written to: $SINGBOX_CONFIG_DIR\config.json"
+
+        New-Item -ItemType Directory -Path $SINGBOX_USER_CONFIG_DIR -Force | Out-Null
+        Copy-Contrib $cfgSrc (Join-Path $SINGBOX_USER_CONFIG_DIR "core_override_config.json")
+        Write-Info "Sing-box core override written to: $SINGBOX_USER_CONFIG_DIR\core_override_config.json"
+    }
+}
+
+# --- Optional downloads ---
+function Invoke-OptionalDownloads {
+    if ($Core -eq "mihomo" -or $Core -eq "all") {
+        $response = Read-Host "Do you want to download templates for mihomo? (y/N)"
+        if ($response -eq "y" -or $response -eq "Y") {
+            Write-Info "Downloading mihomo templates..."
+            Copy-Contrib "templates/mihomo/common_tpl.yaml" (Join-Path $MIHOMO_USER_CONFIG_DIR "templates\common_tpl.yaml")
+            Copy-Contrib "templates/mihomo/generic_tpl.yaml" (Join-Path $MIHOMO_USER_CONFIG_DIR "templates\generic_tpl.yaml")
+            Copy-Contrib "templates/mihomo/generic_tpl_with_all.yaml" (Join-Path $MIHOMO_USER_CONFIG_DIR "templates\generic_tpl_with_all.yaml")
+            Copy-Contrib "templates/mihomo/generic_tpl_with_filter.yaml" (Join-Path $MIHOMO_USER_CONFIG_DIR "templates\generic_tpl_with_filter.yaml")
+            Copy-Contrib "templates/mihomo/generic_tpl_with_ruleset.yaml" (Join-Path $MIHOMO_USER_CONFIG_DIR "templates\generic_tpl_with_ruleset.yaml")
+        }
+
+        $response = Read-Host "Do you want to download rules-dat? (y/N)"
+        if ($response -eq "y" -or $response -eq "Y") {
+            Write-Info "Downloading rules-dat..."
+            Invoke-WebRequest -Uri "https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/geoip.metadb" -OutFile (Join-Path $MIHOMO_CONFIG_DIR "geoip.metadb") -UseBasicParsing
+            Invoke-WebRequest -Uri "https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/geosite.dat" -OutFile (Join-Path $MIHOMO_CONFIG_DIR "GeoSite.dat") -UseBasicParsing
+        }
+    }
+
+    if ($Core -eq "sing-box" -or $Core -eq "all") {
+        $response = Read-Host "Do you want to download templates for sing-box? (y/N)"
+        if ($response -eq "y" -or $response -eq "Y") {
+            Write-Info "Downloading sing-box templates..."
+            Copy-Contrib "templates/sing-box/v1.12-common_tpl.json" (Join-Path $SINGBOX_USER_CONFIG_DIR "templates\v1.12-common_tpl.json")
+            Copy-Contrib "templates/sing-box/v1.12-tun_fakeip_bypass_dnsleak.json" (Join-Path $SINGBOX_USER_CONFIG_DIR "templates\v1.12-tun_fakeip_bypass_dnsleak.json")
+            Copy-Contrib "templates/sing-box/v1.12-tun_fakeip_bypass_no_dnsleak.json" (Join-Path $SINGBOX_USER_CONFIG_DIR "templates\v1.12-tun_fakeip_bypass_no_dnsleak.json")
+            Copy-Contrib "templates/sing-box/v1.12-tun_ipv4_ipv6.json" (Join-Path $SINGBOX_USER_CONFIG_DIR "templates\v1.12-tun_ipv4_ipv6.json")
+            Copy-Contrib "templates/sing-box/v1.12-tun_ipv4_only.json" (Join-Path $SINGBOX_USER_CONFIG_DIR "templates\v1.12-tun_ipv4_only.json")
+        }
+    }
+}
+
+# --- Main ---
+function Main {
+    if ((Get-OS) -ne "windows") {
+        Write-ErrorLog "This script is for Windows only. Use the bash install script for Linux/macOS."
+        exit 1
+    }
+
+    Test-ValidInstallDir $InstallDir
+    Resolve-Paths
+
+    Write-Info "Install directory: $InstallDir"
+    Write-Info "Core type: $Core"
+    Write-Info "Repo: $Repo"
+    Write-Info "Branch: $Branch"
+
+    # Create necessary directories
+    if ($Core -eq "mihomo" -or $Core -eq "all") {
+        New-Item -ItemType Directory -Path $MIHOMO_CONFIG_DIR -Force | Out-Null
+    }
+    if ($Core -eq "sing-box" -or $Core -eq "all") {
+        New-Item -ItemType Directory -Path $SINGBOX_CONFIG_DIR -Force | Out-Null
+    }
+    New-Item -ItemType Directory -Path $CLASHTUI_CONFIG_DIR -Force | Out-Null
+
+    # Install cores
+    switch ($Core) {
+        "mihomo"   { Install-Mihomo }
+        "sing-box" { Install-SingBox }
+        "all"      { Install-Mihomo; Install-SingBox }
+    }
+
+    # Install clashtui (binary + config)
+    Install-ClashTui $Core
+
+    # Create core configs
+    New-CoreConfigs $Core
+
+    # Optional downloads
+    Invoke-OptionalDownloads
+
+    Write-Info "Installed cores: $Core"
+    Write-Info "Clashtui binary: $INSTALL_BIN\clashtui.exe"
+    Write-Info "Clashtui config: $CLASHTUI_CONFIG_DIR"
+    Write-Info "Core configs written to core config directories"
+    Write-Info "Install directory: $InstallDir"
+    Write-Info "Use ClashTui's CoreSrvCtl to manage core services (install/start/stop via nssm)."
+}
+
+Main

--- a/install.ps1
+++ b/install.ps1
@@ -416,25 +416,25 @@ function New-ClashTuiConfig {
     $configPath = Join-Path $CLASHTUI_CONFIG_DIR "config.yaml"
     Backup-File $configPath
 
-    $mihomoBinDir = $INSTALL_DIR_MIHOMO -replace '\\', '\\'
-    $singboxBinDir = $INSTALL_DIR_SINGBOX -replace '\\', '\\'
-    $mihomoCfgDir = $MIHOMO_CONFIG_DIR -replace '\\', '\\'
-    $singboxCfgDir = $SINGBOX_CONFIG_DIR -replace '\\', '\\'
+    $mihomoBinDir = ($INSTALL_DIR_MIHOMO -replace '\\', '/')
+    $singboxBinDir = ($INSTALL_DIR_SINGBOX -replace '\\', '/')
+    $mihomoCfgDir = ($MIHOMO_CONFIG_DIR -replace '\\', '/')
+    $singboxCfgDir = ($SINGBOX_CONFIG_DIR -replace '\\', '/')
 
     $configContent = @"
 mihomo:
   core:
     config_dir: ${mihomoCfgDir}
-    bin_path: ${mihomoBinDir}\mihomo.exe
-    config_path: ${mihomoCfgDir}\config.yaml
+    bin_path: ${mihomoBinDir}/mihomo.exe
+    config_path: ${mihomoCfgDir}/config.yaml
   core_service:
     service_name: clashtui_mihomo
     is_user: false
 singbox:
   core:
-    bin_path: ${singboxBinDir}\sing-box.exe
+    bin_path: ${singboxBinDir}/sing-box.exe
     config_dir: ${singboxCfgDir}
-    config_path: ${singboxCfgDir}\config.json
+    config_path: ${singboxCfgDir}/config.json
   core_service:
     service_name: clashtui_singbox
     is_user: false
@@ -500,11 +500,11 @@ function New-CoreConfigs {
 
         $cfgSrc = "default_configs/mihomo/core_override_config.yaml"
         Copy-Contrib $cfgSrc (Join-Path $MIHOMO_CONFIG_DIR "config.yaml")
-        Write-Info "Mihomo core config written to: $MIHOMO_CONFIG_DIR\config.yaml"
+        Write-Info "Mihomo core config written to: $MIHOMO_CONFIG_DIR/config.yaml"
 
         New-Item -ItemType Directory -Path $MIHOMO_USER_CONFIG_DIR -Force | Out-Null
         Copy-Contrib $cfgSrc (Join-Path $MIHOMO_USER_CONFIG_DIR "core_override_config.yaml")
-        Write-Info "Mihomo core override written to: $MIHOMO_USER_CONFIG_DIR\core_override_config.yaml"
+        Write-Info "Mihomo core override written to: $MIHOMO_USER_CONFIG_DIR/core_override_config.yaml"
     }
 
     if ($CoreType -eq "sing-box" -or $CoreType -eq "all") {
@@ -512,11 +512,11 @@ function New-CoreConfigs {
 
         $cfgSrc = "default_configs/sing-box/core_override_config.json"
         Copy-Contrib $cfgSrc (Join-Path $SINGBOX_CONFIG_DIR "config.json")
-        Write-Info "Sing-box core config written to: $SINGBOX_CONFIG_DIR\config.json"
+        Write-Info "Sing-box core config written to: $SINGBOX_CONFIG_DIR/config.json"
 
         New-Item -ItemType Directory -Path $SINGBOX_USER_CONFIG_DIR -Force | Out-Null
         Copy-Contrib $cfgSrc (Join-Path $SINGBOX_USER_CONFIG_DIR "core_override_config.json")
-        Write-Info "Sing-box core override written to: $SINGBOX_USER_CONFIG_DIR\core_override_config.json"
+        Write-Info "Sing-box core override written to: $SINGBOX_USER_CONFIG_DIR/core_override_config.json"
     }
 }
 
@@ -526,11 +526,11 @@ function Invoke-OptionalDownloads {
         $response = Read-Host "Do you want to download templates for mihomo? (y/N)"
         if ($response -eq "y" -or $response -eq "Y") {
             Write-Info "Downloading mihomo templates..."
-            Copy-Contrib "templates/mihomo/common_tpl.yaml" (Join-Path $MIHOMO_USER_CONFIG_DIR "templates\common_tpl.yaml")
-            Copy-Contrib "templates/mihomo/generic_tpl.yaml" (Join-Path $MIHOMO_USER_CONFIG_DIR "templates\generic_tpl.yaml")
-            Copy-Contrib "templates/mihomo/generic_tpl_with_all.yaml" (Join-Path $MIHOMO_USER_CONFIG_DIR "templates\generic_tpl_with_all.yaml")
-            Copy-Contrib "templates/mihomo/generic_tpl_with_filter.yaml" (Join-Path $MIHOMO_USER_CONFIG_DIR "templates\generic_tpl_with_filter.yaml")
-            Copy-Contrib "templates/mihomo/generic_tpl_with_ruleset.yaml" (Join-Path $MIHOMO_USER_CONFIG_DIR "templates\generic_tpl_with_ruleset.yaml")
+            Copy-Contrib "templates/mihomo/common_tpl.yaml" (Join-Path $MIHOMO_USER_CONFIG_DIR "templates/common_tpl.yaml")
+            Copy-Contrib "templates/mihomo/generic_tpl.yaml" (Join-Path $MIHOMO_USER_CONFIG_DIR "templates/generic_tpl.yaml")
+            Copy-Contrib "templates/mihomo/generic_tpl_with_all.yaml" (Join-Path $MIHOMO_USER_CONFIG_DIR "templates/generic_tpl_with_all.yaml")
+            Copy-Contrib "templates/mihomo/generic_tpl_with_filter.yaml" (Join-Path $MIHOMO_USER_CONFIG_DIR "templates/generic_tpl_with_filter.yaml")
+            Copy-Contrib "templates/mihomo/generic_tpl_with_ruleset.yaml" (Join-Path $MIHOMO_USER_CONFIG_DIR "templates/generic_tpl_with_ruleset.yaml")
         }
 
         $response = Read-Host "Do you want to download rules-dat? (y/N)"
@@ -545,11 +545,11 @@ function Invoke-OptionalDownloads {
         $response = Read-Host "Do you want to download templates for sing-box? (y/N)"
         if ($response -eq "y" -or $response -eq "Y") {
             Write-Info "Downloading sing-box templates..."
-            Copy-Contrib "templates/sing-box/v1.12-common_tpl.json" (Join-Path $SINGBOX_USER_CONFIG_DIR "templates\v1.12-common_tpl.json")
-            Copy-Contrib "templates/sing-box/v1.12-tun_fakeip_bypass_dnsleak.json" (Join-Path $SINGBOX_USER_CONFIG_DIR "templates\v1.12-tun_fakeip_bypass_dnsleak.json")
-            Copy-Contrib "templates/sing-box/v1.12-tun_fakeip_bypass_no_dnsleak.json" (Join-Path $SINGBOX_USER_CONFIG_DIR "templates\v1.12-tun_fakeip_bypass_no_dnsleak.json")
-            Copy-Contrib "templates/sing-box/v1.12-tun_ipv4_ipv6.json" (Join-Path $SINGBOX_USER_CONFIG_DIR "templates\v1.12-tun_ipv4_ipv6.json")
-            Copy-Contrib "templates/sing-box/v1.12-tun_ipv4_only.json" (Join-Path $SINGBOX_USER_CONFIG_DIR "templates\v1.12-tun_ipv4_only.json")
+            Copy-Contrib "templates/sing-box/v1.12-common_tpl.json" (Join-Path $SINGBOX_USER_CONFIG_DIR "templates/v1.12-common_tpl.json")
+            Copy-Contrib "templates/sing-box/v1.12-tun_fakeip_bypass_dnsleak.json" (Join-Path $SINGBOX_USER_CONFIG_DIR "templates/v1.12-tun_fakeip_bypass_dnsleak.json")
+            Copy-Contrib "templates/sing-box/v1.12-tun_fakeip_bypass_no_dnsleak.json" (Join-Path $SINGBOX_USER_CONFIG_DIR "templates/v1.12-tun_fakeip_bypass_no_dnsleak.json")
+            Copy-Contrib "templates/sing-box/v1.12-tun_ipv4_ipv6.json" (Join-Path $SINGBOX_USER_CONFIG_DIR "templates/v1.12-tun_ipv4_ipv6.json")
+            Copy-Contrib "templates/sing-box/v1.12-tun_ipv4_only.json" (Join-Path $SINGBOX_USER_CONFIG_DIR "templates/v1.12-tun_ipv4_only.json")
         }
     }
 }
@@ -595,7 +595,7 @@ function Main {
     Invoke-OptionalDownloads
 
     Write-Info "Installed cores: $Core"
-    Write-Info "Clashtui binary: $INSTALL_BIN\clashtui.exe"
+    Write-Info "Clashtui binary: $INSTALL_BIN/clashtui.exe"
     Write-Info "Clashtui config: $CLASHTUI_CONFIG_DIR"
     Write-Info "Core configs written to core config directories"
     Write-Info "Install directory: $InstallDir"

--- a/src/config.rs
+++ b/src/config.rs
@@ -318,6 +318,12 @@ pub fn config_dir_path() -> PathBuf {
 pub fn config_root_path() -> PathBuf {
     CONFIG_ROOT.get().unwrap().clone()
 }
+pub fn core_data_dir(core_type: CoreType) -> PathBuf {
+    match core_type {
+        CoreType::Mihomo => mihomo_dir(),
+        CoreType::Singbox => singbox_dir(),
+    }
+}
 pub fn template_path() -> PathBuf {
     mihomo_dir().join(defs::TEMPLATE_DIR)
 }
@@ -389,5 +395,43 @@ mod tests {
         assert!(is_core_mismatch());
         set_core_mismatch(false);
         assert!(!is_core_mismatch());
+    }
+
+    #[test]
+    fn core_data_dir_returns_correct_subdir_per_core_type() {
+        let tmp = std::env::temp_dir().join(format!("clashtui-test-{}", fastrand::u32(..)));
+        std::fs::create_dir_all(&tmp).unwrap();
+        struct Cleanup(std::path::PathBuf);
+        impl Drop for Cleanup {
+            fn drop(&mut self) {
+                let _ = std::fs::remove_dir_all(&self.0);
+            }
+        }
+        let _cleanup = Cleanup(tmp.clone());
+
+        init(Some(tmp.clone())).unwrap();
+
+        let mihomo_dir = core_data_dir(CoreType::Mihomo);
+        assert!(
+            mihomo_dir.ends_with("mihomo"),
+            "expected path ending with 'mihomo', got: {mihomo_dir:?}"
+        );
+
+        let singbox_dir = core_data_dir(CoreType::Singbox);
+        assert!(
+            singbox_dir.ends_with("sing-box"),
+            "expected path ending with 'sing-box', got: {singbox_dir:?}"
+        );
+    }
+
+    #[test]
+    fn core_install_dir_is_parent_of_config_dir() {
+        let config_dir = "/opt/clashtui/mihomo/config";
+        let parent = std::path::Path::new(config_dir).parent().unwrap();
+        assert_eq!(parent, std::path::Path::new("/opt/clashtui/mihomo"));
+
+        let config_dir = "/opt/clashtui/sing-box/config";
+        let parent = std::path::Path::new(config_dir).parent().unwrap();
+        assert_eq!(parent, std::path::Path::new("/opt/clashtui/sing-box"));
     }
 }

--- a/src/config/core.rs
+++ b/src/config/core.rs
@@ -67,6 +67,41 @@ pub struct ConfigFile {
 }
 impl Default for ConfigFile {
     fn default() -> Self {
+        #[cfg(windows)]
+        {
+            let local_appdata = std::env::var("LOCALAPPDATA").unwrap_or_else(|_| {
+                let home = std::env::var("USERPROFILE").unwrap_or_default();
+                format!("{home}\\AppData\\Local")
+            });
+            let base = format!("{local_appdata}\\clashtui");
+            Self {
+                mihomo: MihomoSection {
+                    core: CoreConfig {
+                        config_dir: format!("{base}\\mihomo\\config"),
+                        bin_path: format!("{base}\\mihomo\\mihomo.exe"),
+                        config_path: format!("{base}\\mihomo\\config\\config.yaml"),
+                    },
+                    core_service: CoreServiceConfig {
+                        service_name: "clashtui_mihomo".into(),
+                        is_user: false,
+                    },
+                },
+                singbox: SingboxSection {
+                    core: CoreConfig {
+                        config_dir: format!("{base}\\sing-box\\config"),
+                        bin_path: format!("{base}\\sing-box\\sing-box.exe"),
+                        config_path: format!("{base}\\sing-box\\config\\config.json"),
+                    },
+                    core_service: CoreServiceConfig {
+                        service_name: "clashtui_singbox".into(),
+                        is_user: false,
+                    },
+                },
+                timeout: Default::default(),
+                extra: Default::default(),
+            }
+        }
+        #[cfg(not(windows))]
         Self {
             mihomo: MihomoSection {
                 core: CoreConfig {

--- a/src/config/core.rs
+++ b/src/config/core.rs
@@ -141,16 +141,22 @@ pub struct Extra {
 }
 impl Default for Extra {
     fn default() -> Self {
-        let common_cmd = if cfg!(windows) {
-            "start %s"
+        if cfg!(windows) {
+            Self {
+                edit_cmd: r#"notepad.exe "%s""#.to_owned(),
+                open_dir_cmd: r#"explorer "%s""#.to_owned(),
+            }
         } else if cfg!(target_os = "macos") {
-            "open %s"
+            Self {
+                edit_cmd: r#"open -t "%s""#.to_owned(),
+                open_dir_cmd: r#"open "%s""#.to_owned(),
+            }
         } else {
-            "xdg-open %s"
-        };
-        Self {
-            edit_cmd: common_cmd.to_owned(),
-            open_dir_cmd: common_cmd.to_owned(),
+            let cmd = r#"xdg-open "%s""#.to_owned();
+            Self {
+                edit_cmd: cmd.clone(),
+                open_dir_cmd: cmd,
+            }
         }
     }
 }
@@ -354,10 +360,10 @@ profiles:
 
     #[cfg(target_os = "macos")]
     #[test]
-    fn extra_default_macos_uses_open() {
+    fn extra_default_macos() {
         let extra = Extra::default();
-        assert_eq!(extra.edit_cmd, "open %s");
-        assert_eq!(extra.open_dir_cmd, "open %s");
+        assert_eq!(extra.edit_cmd, r#"open -t "%s""#);
+        assert_eq!(extra.open_dir_cmd, r#"open "%s""#);
     }
 
     #[cfg(not(target_os = "macos"))]

--- a/src/config/core.rs
+++ b/src/config/core.rs
@@ -69,17 +69,19 @@ impl Default for ConfigFile {
     fn default() -> Self {
         #[cfg(windows)]
         {
-            let local_appdata = std::env::var("LOCALAPPDATA").unwrap_or_else(|_| {
-                let home = std::env::var("USERPROFILE").unwrap_or_default();
-                format!("{home}\\AppData\\Local")
-            });
-            let base = format!("{local_appdata}\\clashtui");
+            let local_appdata = std::env::var("LOCALAPPDATA")
+                .unwrap_or_else(|_| {
+                    let home = std::env::var("USERPROFILE").unwrap_or_default();
+                    format!("{home}/AppData/Local")
+                })
+                .replace('\\', "/");
+            let base = format!("{local_appdata}/clashtui");
             Self {
                 mihomo: MihomoSection {
                     core: CoreConfig {
-                        config_dir: format!("{base}\\mihomo\\config"),
-                        bin_path: format!("{base}\\mihomo\\mihomo.exe"),
-                        config_path: format!("{base}\\mihomo\\config\\config.yaml"),
+                        config_dir: format!("{base}/mihomo/config"),
+                        bin_path: format!("{base}/mihomo/mihomo.exe"),
+                        config_path: format!("{base}/mihomo/config/config.yaml"),
                     },
                     core_service: CoreServiceConfig {
                         service_name: "clashtui_mihomo".into(),
@@ -88,9 +90,9 @@ impl Default for ConfigFile {
                 },
                 singbox: SingboxSection {
                     core: CoreConfig {
-                        config_dir: format!("{base}\\sing-box\\config"),
-                        bin_path: format!("{base}\\sing-box\\sing-box.exe"),
-                        config_path: format!("{base}\\sing-box\\config\\config.json"),
+                        config_dir: format!("{base}/sing-box/config"),
+                        bin_path: format!("{base}/sing-box/sing-box.exe"),
+                        config_path: format!("{base}/sing-box/config/config.json"),
                     },
                     core_service: CoreServiceConfig {
                         service_name: "clashtui_singbox".into(),

--- a/src/config/core.rs
+++ b/src/config/core.rs
@@ -366,13 +366,33 @@ profiles:
         assert_eq!(extra.open_dir_cmd, r#"open "%s""#);
     }
 
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(windows)]
     #[test]
-    fn extra_default_non_macos_not_open() {
+    fn extra_default_windows() {
         let extra = Extra::default();
-        // On non-macOS platforms, the default should NOT be "open %s"
-        assert_ne!(extra.edit_cmd, "open %s");
-        assert_ne!(extra.open_dir_cmd, "open %s");
+        assert_eq!(extra.edit_cmd, r#"notepad.exe "%s""#);
+        assert_eq!(extra.open_dir_cmd, r#"explorer "%s""#);
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    #[test]
+    fn extra_default_linux() {
+        let extra = Extra::default();
+        assert_eq!(extra.edit_cmd, r#"xdg-open "%s""#);
+        assert_eq!(extra.open_dir_cmd, r#"xdg-open "%s""#);
+    }
+
+    #[test]
+    fn extra_empty_template_stays_empty() {
+        // Serde: explicit empty strings in config MUST NOT trigger platform defaults
+        // (shell_spawn handles the empty-case fallback at runtime)
+        let yaml = r#"
+edit_cmd: ""
+open_dir_cmd: ""
+"#;
+        let extra: Extra = serde_yml::from_str(yaml).unwrap();
+        assert_eq!(extra.edit_cmd, "");
+        assert_eq!(extra.open_dir_cmd, "");
     }
 
     #[test]

--- a/src/functions/command.rs
+++ b/src/functions/command.rs
@@ -142,7 +142,7 @@ fn svc_operation(op: &str, password: Option<&str>, core_type: Option<CoreType>) 
         return launchd_operation(op, service_name, is_user, password);
     }
 
-    // nssm install/remove need special dispatch (launch args)
+    #[cfg(target_os = "windows")]
     if matches!(host, ServiceController::Nssm) {
         return nssm_svc_operation(op, service_name, ct);
     }
@@ -164,6 +164,7 @@ fn svc_operation(op: &str, password: Option<&str>, core_type: Option<CoreType>) 
     }
 }
 
+#[cfg(target_os = "windows")]
 fn nssm_svc_operation(op: &str, service_name: &str, ct: CoreType) -> Result<String> {
     match op {
         "start" | "stop" | "restart" | "reload" => {

--- a/src/functions/command.rs
+++ b/src/functions/command.rs
@@ -335,39 +335,22 @@ pub fn stop_all_services(password: Option<&str>) -> Result<String> {
 }
 
 pub fn edit(path: &str) -> Result<()> {
-    log::debug!("edit: path={path} cmd={}", CONFIG.cfg_file.extra.edit_cmd);
-    spawn(
-        "sh",
-        vec![
-            "-c",
-            CONFIG.cfg_file.extra.edit_cmd.replace("%s", path).as_str(),
-        ],
-    )
+    let tpl = &CONFIG.cfg_file.extra.edit_cmd;
+    log::debug!("edit: path={path} template={tpl}");
+    shell_spawn(tpl, path)
 }
 
 pub fn open_dir(path: &str) -> Result<()> {
-    log::debug!(
-        "open_dir: path={path} cmd={}",
-        CONFIG.cfg_file.extra.open_dir_cmd
-    );
-    spawn(
-        "sh",
-        vec![
-            "-c",
-            CONFIG
-                .cfg_file
-                .extra
-                .open_dir_cmd
-                .replace("%s", path)
-                .as_str(),
-        ],
-    )
+    let tpl = &CONFIG.cfg_file.extra.open_dir_cmd;
+    log::debug!("open_dir: path={path} template={tpl}");
+    shell_spawn(tpl, path)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    #[cfg(target_os = "macos")]
     #[test]
     fn test_launchd_plist_path_user() {
         let path = launchd_plist_path("com.example.service", true);
@@ -379,6 +362,7 @@ mod tests {
         );
     }
 
+    #[cfg(target_os = "macos")]
     #[test]
     fn test_launchd_plist_path_system() {
         let path = launchd_plist_path("com.example.service", false);

--- a/src/functions/command.rs
+++ b/src/functions/command.rs
@@ -1,5 +1,6 @@
 #[cfg_attr(target_os = "linux", path = "command/linux.rs")]
 #[cfg_attr(target_os = "macos", path = "command/macos.rs")]
+#[cfg_attr(target_os = "windows", path = "command/windows.rs")]
 mod platform;
 mod utils;
 
@@ -133,6 +134,11 @@ fn svc_operation(op: &str, password: Option<&str>, core_type: Option<CoreType>) 
         return launchd_operation(op, service_name, is_user, password);
     }
 
+    // nssm install/remove need special dispatch (launch args)
+    if matches!(host, ServiceController::Nssm) {
+        return nssm_svc_operation(op, service_name, ct);
+    }
+
     let svc_args = host.args(op, service_name, is_user);
     if is_user {
         return exec(host.bin_name(), svc_args);
@@ -147,6 +153,28 @@ fn svc_operation(op: &str, password: Option<&str>, core_type: Option<CoreType>) 
             a.extend(argv);
             a
         }),
+    }
+}
+
+fn nssm_svc_operation(op: &str, service_name: &str, ct: CoreType) -> Result<String> {
+    match op {
+        "start" | "stop" | "restart" => {
+            let output = std::process::Command::new("nssm")
+                .args([op, service_name])
+                .output()?;
+            Ok(platform::stringify_output(output))
+        }
+        "install" => {
+            let bin_path = match ct {
+                CoreType::Mihomo => &CONFIG.cfg_file.mihomo.core.bin_path,
+                CoreType::Singbox => &CONFIG.cfg_file.singbox.core.bin_path,
+            };
+            let launch_args = platform::nssm_launch_args(ct);
+            let launch_strs: Vec<&str> = launch_args.iter().map(|s| s.as_str()).collect();
+            platform::nssm_install(service_name, bin_path, &launch_strs)
+        }
+        "remove" => platform::nssm_uninstall(service_name),
+        _ => Err(anyhow::anyhow!("Unknown nssm operation: {op}")),
     }
 }
 
@@ -216,6 +244,14 @@ pub fn restart_core_service(password: Option<&str>, core_type: CoreType) -> Resu
 
 pub fn reload_core_service(password: Option<&str>, core_type: CoreType) -> Result<String> {
     svc_operation("reload", password, Some(core_type))
+}
+
+pub fn install_core_service(password: Option<&str>, core_type: CoreType) -> Result<String> {
+    svc_operation("install", password, Some(core_type))
+}
+
+pub fn uninstall_core_service(password: Option<&str>, core_type: CoreType) -> Result<String> {
+    svc_operation("remove", password, Some(core_type))
 }
 
 pub fn restart_service(password: Option<&str>) -> Result<String> {

--- a/src/functions/command.rs
+++ b/src/functions/command.rs
@@ -123,6 +123,56 @@ pub fn check_config(profile_path: &Path) -> anyhow::Result<()> {
     }
 }
 
+pub fn is_core_service_running() -> Option<bool> {
+    let host = &ServiceController::default();
+    let ct = CONFIG.core_type();
+    let (service_name, is_user) = match ct {
+        CoreType::Mihomo => (
+            &CONFIG.cfg_file.mihomo.core_service.service_name,
+            CONFIG.cfg_file.mihomo.core_service.is_user,
+        ),
+        CoreType::Singbox => (
+            &CONFIG.cfg_file.singbox.core_service.service_name,
+            CONFIG.cfg_file.singbox.core_service.is_user,
+        ),
+    };
+
+    if service_name.is_empty() {
+        return None;
+    }
+
+    #[cfg(target_os = "windows")]
+    if matches!(host, ServiceController::Nssm) {
+        let s = nssm_status(service_name);
+        return Some(s == "active");
+    }
+
+    if matches!(host, ServiceController::Systemd | ServiceController::OpenRc) {
+        let mut args = vec!["is-active"];
+        if is_user {
+            args.push("--user");
+        }
+        args.push(service_name);
+        return std::process::Command::new(host.bin_name())
+            .args(&args)
+            .output()
+            .map(|o| Some(String::from_utf8_lossy(&o.stdout).trim() == "active"))
+            .unwrap_or(None);
+    }
+
+    #[cfg(target_os = "macos")]
+    if matches!(host, ServiceController::Launchd) && is_user {
+        let uid = unsafe { libc::getuid() };
+        return std::process::Command::new("launchctl")
+            .args(["print", &format!("gui/{uid}/{service_name}")])
+            .output()
+            .map(|o| Some(String::from_utf8_lossy(&o.stdout).contains("state = running")))
+            .unwrap_or(None);
+    }
+
+    None
+}
+
 fn svc_operation(op: &str, password: Option<&str>, core_type: Option<CoreType>) -> Result<String> {
     let host = &ServiceController::default();
     let ct = core_type.unwrap_or(CONFIG.core_type());

--- a/src/functions/command.rs
+++ b/src/functions/command.rs
@@ -17,13 +17,21 @@ pub async fn resolve_sudo_password(needs_sudo: bool) -> Result<Option<String>> {
     if !needs_sudo {
         return Ok(None);
     }
-    if !sudo_needs_password() {
+    #[cfg(windows)]
+    {
+        // Windows: each nssm operation auto-elevates via UAC
         return Ok(None);
     }
-    match crate::tui::prompt_sudo_password().await {
-        Some(pw) if pw.is_empty() => Ok(None),
-        Some(pw) => Ok(Some(pw)),
-        None => Err(anyhow::anyhow!("cancelled")),
+    #[cfg(not(windows))]
+    {
+        if !sudo_needs_password() {
+            return Ok(None);
+        }
+        match crate::tui::prompt_sudo_password().await {
+            Some(pw) if pw.is_empty() => Ok(None),
+            Some(pw) => Ok(Some(pw)),
+            None => Err(anyhow::anyhow!("cancelled")),
+        }
     }
 }
 
@@ -158,11 +166,10 @@ fn svc_operation(op: &str, password: Option<&str>, core_type: Option<CoreType>) 
 
 fn nssm_svc_operation(op: &str, service_name: &str, ct: CoreType) -> Result<String> {
     match op {
-        "start" | "stop" | "restart" => {
-            let output = std::process::Command::new("nssm")
-                .args([op, service_name])
-                .output()?;
-            Ok(platform::stringify_output(output))
+        "start" | "stop" | "restart" | "reload" => {
+            let op = if op == "reload" { "restart" } else { op };
+            let args = [op, service_name];
+            platform::nssm_runas_or_direct(service_name, &args)
         }
         "install" => {
             let bin_path = match ct {

--- a/src/functions/command/utils.rs
+++ b/src/functions/command/utils.rs
@@ -48,3 +48,22 @@ pub fn spawn(pgm: &str, args: Vec<&str>) -> Result<()> {
         .spawn()?;
     Ok(())
 }
+
+pub fn shell_spawn(cmd_template: &str, path: &str) -> Result<()> {
+    if cmd_template.is_empty() {
+        if cfg!(windows) {
+            spawn("cmd", vec!["/c", "start", "", path])
+        } else if cfg!(target_os = "macos") {
+            spawn("sh", vec!["-c", &format!("open \"{}\"", path)])
+        } else {
+            spawn("sh", vec!["-c", &format!("xdg-open \"{}\"", path)])
+        }
+    } else {
+        let cmd = cmd_template.replace("%s", path);
+        if cfg!(windows) {
+            spawn("cmd", vec!["/c", &cmd])
+        } else {
+            spawn("sh", vec!["-c", &cmd])
+        }
+    }
+}

--- a/src/functions/command/windows.rs
+++ b/src/functions/command/windows.rs
@@ -1,0 +1,215 @@
+use super::*;
+use std::path::PathBuf;
+
+// ============================================================================
+// Platform stubs — file permissions / TUN capability (no-ops on Windows)
+// ============================================================================
+
+pub fn correct_cap_for_tun() -> Result<String> {
+    Ok("No setcap on Windows".into())
+}
+
+pub fn find_files_not_group_writable(_dir: &Path) -> Vec<PathBuf> {
+    Vec::new()
+}
+
+pub fn find_files_not_in_group(_dir: &Path, _group_name: &str) -> Vec<PathBuf> {
+    Vec::new()
+}
+
+pub fn get_dir_group_name(_dir: &Path) -> Option<String> {
+    None
+}
+
+pub fn check_file_permissions(_dir: &Path) -> bool {
+    true
+}
+
+pub fn repair_file_permissions(_dir: &Path, _group_name: &str) -> Result<String> {
+    Ok("Permissions OK on Windows".into())
+}
+
+pub(super) fn stringify_output(output: std::process::Output) -> String {
+    let stdout_str = String::from_utf8_lossy(&output.stdout);
+    let stderr_str = String::from_utf8_lossy(&output.stderr);
+
+    format!(
+        r#"{}
+        Stdout:
+        {}
+
+        Stderr:
+        {}
+        "#,
+        if output.status.success() {
+            "OK".to_owned()
+        } else {
+            format!("Error({})", output.status)
+        },
+        stdout_str,
+        stderr_str
+    )
+}
+
+// ============================================================================
+// nssm CLI service operations
+// ============================================================================
+
+use crate::config::CoreType;
+use crate::config::CONFIG;
+
+fn nssm_bin() -> &'static str {
+    "nssm"
+}
+
+fn nssm_cmd(args: &[&str]) -> Result<std::process::Output> {
+    std::process::Command::new(nssm_bin())
+        .args(args)
+        .output()
+        .map_err(|e| anyhow::anyhow!("Failed to run nssm: {e}"))
+}
+
+/// Install a Windows service via nssm.
+/// `service_name`: service display name
+/// `bin_path`: full path to the .exe
+/// `launch_args`: arguments passed to the binary at service start
+pub fn nssm_install(service_name: &str, bin_path: &str, launch_args: &[&str]) -> Result<String> {
+    let mut args = vec!["install", service_name, bin_path];
+    args.extend(launch_args);
+    let output = nssm_cmd(&args)?;
+    Ok(stringify_output(output))
+}
+
+/// Uninstall a Windows service via nssm (nssm stops it if running).
+pub fn nssm_uninstall(service_name: &str) -> Result<String> {
+    let output = nssm_cmd(&["remove", service_name, "confirm"])?;
+    Ok(stringify_output(output))
+}
+
+/// Query nssm service status.
+/// Returns: "active" | "inactive" | "uninstalled" | "?"
+pub fn nssm_status(service_name: &str) -> String {
+    let output = match nssm_cmd(&["status", service_name]) {
+        Ok(o) => o,
+        Err(_) => return "uninstalled".to_owned(),
+    };
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stdout = stdout.trim().to_uppercase();
+    if stdout.contains("SERVICE_RUNNING") {
+        "active".to_owned()
+    } else if stdout.contains("SERVICE_STOPPED") || stdout.contains("SERVICE_PAUSED") {
+        "inactive".to_owned()
+    } else {
+        "uninstalled".to_owned()
+    }
+}
+
+/// Build nssm launch args for the current core type.
+/// mihomo: `-d <config_dir>`
+/// sing-box: `-D <config_dir> -c <config_path> run`
+pub fn nssm_launch_args(ct: CoreType) -> Vec<String> {
+    match ct {
+        CoreType::Mihomo => {
+            let cfg = &CONFIG.cfg_file.mihomo.core;
+            vec!["-d".to_owned(), cfg.config_dir.clone()]
+        }
+        CoreType::Singbox => {
+            let cfg = &CONFIG.cfg_file.singbox.core;
+            vec![
+                "-D".to_owned(),
+                cfg.config_dir.clone(),
+                "-c".to_owned(),
+                cfg.config_path.clone(),
+                "run".to_owned(),
+            ]
+        }
+    }
+}
+
+// ============================================================================
+// System proxy toggle (Windows registry)
+// ============================================================================
+
+const PROXY_REG_PATH: &str =
+    r"Software\Microsoft\Windows\CurrentVersion\Internet Settings";
+
+/// Returns true if the system proxy is currently enabled.
+pub fn get_system_proxy_state() -> Result<bool> {
+    let hkcu = winreg::RegKey::predef(winreg::enums::HKEY_CURRENT_USER);
+    let settings = hkcu
+        .open_subkey_with_flags(PROXY_REG_PATH, winreg::enums::KEY_READ)
+        .map_err(|e| anyhow::anyhow!("Failed to open registry key: {e}"))?;
+    let proxy_enable: u32 = settings
+        .get_value("ProxyEnable")
+        .map_err(|e| anyhow::anyhow!("Failed to read ProxyEnable: {e}"))?;
+    Ok(proxy_enable == 1)
+}
+
+/// Enable system proxy on localhost:<port>.
+pub fn enable_system_proxy(port: u16) -> Result<()> {
+    let hkcu = winreg::RegKey::predef(winreg::enums::HKEY_CURRENT_USER);
+    let (settings, _) = hkcu
+        .create_subkey(PROXY_REG_PATH)
+        .map_err(|e| anyhow::anyhow!("Failed to open/create registry key: {e}"))?;
+    settings
+        .set_value("ProxyEnable", &1u32)
+        .map_err(|e| anyhow::anyhow!("Failed to write ProxyEnable: {e}"))?;
+    settings
+        .set_value("ProxyServer", &format!("127.0.0.1:{port}"))
+        .map_err(|e| anyhow::anyhow!("Failed to write ProxyServer: {e}"))?;
+    settings
+        .set_value("ProxyOverride", &"<-loopback>")
+        .map_err(|e| anyhow::anyhow!("Failed to write ProxyOverride: {e}"))?;
+    broadcast_settings_change();
+    Ok(())
+}
+
+/// Disable system proxy.
+pub fn disable_system_proxy() -> Result<()> {
+    let hkcu = winreg::RegKey::predef(winreg::enums::HKEY_CURRENT_USER);
+    let (settings, _) = hkcu
+        .create_subkey(PROXY_REG_PATH)
+        .map_err(|e| anyhow::anyhow!("Failed to open/create registry key: {e}"))?;
+    settings
+        .set_value("ProxyEnable", &0u32)
+        .map_err(|e| anyhow::anyhow!("Failed to write ProxyEnable: {e}"))?;
+    broadcast_settings_change();
+    Ok(())
+}
+
+/// Broadcast WM_SETTINGCHANGE so Windows refreshes proxy settings.
+fn broadcast_settings_change() {
+    use windows::Win32::Foundation::{LPARAM, WPARAM};
+    use windows::Win32::UI::WindowsAndMessaging::{
+        HWND_BROADCAST, SendMessageTimeoutW, SMTO_ABORTIFHUNG, WM_SETTINGCHANGE,
+    };
+    let _ = unsafe {
+        SendMessageTimeoutW(
+            HWND_BROADCAST,
+            WM_SETTINGCHANGE,
+            WPARAM(0),
+            LPARAM(0),
+            SMTO_ABORTIFHUNG,
+            5000,
+            None,
+        )
+    };
+}
+
+/// Retrieve the mixed inbound port from the core REST API (`GET /configs`).
+pub fn get_mixed_port() -> Result<u16> {
+    use crate::functions::restful::config_struct::ClashConfig;
+    let resp = minreq::get(format!(
+        "{}/configs",
+        CONFIG.controller_for_core()
+    ))
+    .with_timeout(5)
+    .send()
+    .map_err(|e| anyhow::anyhow!("Failed to fetch /configs: {e}"))?;
+    let cfg: ClashConfig =
+        serde_json::from_str(resp.as_str().map_err(|e| anyhow::anyhow!("{e}"))?)
+            .map_err(|e| anyhow::anyhow!("Failed to parse /configs: {e}"))?;
+    cfg.mixed_port
+        .or(cfg.port)
+        .ok_or_else(|| anyhow::anyhow!("No mixed_port or port found in /configs"))
+}

--- a/src/functions/command/windows.rs
+++ b/src/functions/command/windows.rs
@@ -69,21 +69,23 @@ fn nssm_cmd(args: &[&str]) -> Result<std::process::Output> {
         .map_err(|e| anyhow::anyhow!("Failed to run nssm: {e}"))
 }
 
-/// Install a Windows service via nssm.
+/// Install a Windows service via nssm (auto-elevates via UAC if needed).
 /// `service_name`: service display name
 /// `bin_path`: full path to the .exe
 /// `launch_args`: arguments passed to the binary at service start
 pub fn nssm_install(service_name: &str, bin_path: &str, launch_args: &[&str]) -> Result<String> {
     let mut args = vec!["install", service_name, bin_path];
     args.extend(launch_args);
-    let output = nssm_cmd(&args)?;
-    Ok(stringify_output(output))
+    nssm_runas_or_direct(service_name, &args)
 }
 
-/// Uninstall a Windows service via nssm (nssm stops it if running).
+/// Uninstall a Windows service via nssm (auto-elevates via UAC if needed).
+/// Stops the service first, then removes it.
 pub fn nssm_uninstall(service_name: &str) -> Result<String> {
-    let output = nssm_cmd(&["remove", service_name, "confirm"])?;
-    Ok(stringify_output(output))
+    // Best-effort stop before remove — ignore errors (service may already be stopped)
+    let _ = nssm_runas_or_direct(service_name, &["stop", service_name]);
+    let args = ["remove", service_name, "confirm"];
+    nssm_runas_or_direct(service_name, &args)
 }
 
 /// Query nssm service status.
@@ -124,6 +126,114 @@ pub fn nssm_launch_args(ct: CoreType) -> Vec<String> {
             ]
         }
     }
+}
+
+// ============================================================================
+// Elevation
+// ============================================================================
+
+pub fn is_elevated() -> bool {
+    use windows::Win32::Foundation::{CloseHandle, HANDLE};
+    use windows::Win32::Security::{
+        GetTokenInformation, TokenElevation, TOKEN_ELEVATION, TOKEN_QUERY,
+    };
+    use windows::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+
+    let mut token = HANDLE::default();
+    unsafe {
+        if OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token).is_err() {
+            return false;
+        }
+        let mut elevation: TOKEN_ELEVATION = std::mem::zeroed();
+        let mut size: u32 = std::mem::size_of::<TOKEN_ELEVATION>() as u32;
+        let result = GetTokenInformation(
+            token,
+            TokenElevation,
+            Some(&mut elevation as *mut _ as *mut std::ffi::c_void),
+            size,
+            &mut size,
+        );
+        let _ = CloseHandle(token);
+        result.is_ok() && elevation.TokenIsElevated != 0
+    }
+}
+
+/// Run a command via PowerShell's `Start-Process -Verb RunAs` (UAC elevation).
+/// Distinguishes UAC cancellation (exit code 1223) from command failure.
+fn runas(cmd: &str, args: &[&str]) -> Result<()> {
+    let arg_list = args
+        .iter()
+        .map(|a| a.replace('\\', "/"))
+        .collect::<Vec<_>>()
+        .join(" ");
+    // PowerShell: catch Start-Process errors (e.g. UAC cancelled) and
+    // exit with 1223 (ERROR_CANCELLED).  On success, exit with nssm's
+    // exit code so we can tell whether the command itself failed.
+    let ps = format!(
+        "\
+try {{
+    $p = Start-Process -FilePath '{cmd}' -ArgumentList '{arg_list}' \
+         -Verb RunAs -Wait -PassThru -ErrorAction Stop
+    exit $p.ExitCode
+}} catch {{
+    exit 1223
+}}"
+    );
+    let output = std::process::Command::new("powershell")
+        .args(["-NoProfile", "-Command", &ps])
+        .output()
+        .map_err(|e| anyhow::anyhow!("Failed to launch PowerShell: {e}"))?;
+
+    let code = output.status.code().unwrap_or(-1);
+    if code == 0 {
+        return Ok(());
+    }
+    if code == 1223 {
+        return Err(anyhow::anyhow!(
+            "Administrator privileges are required to manage services.\n\
+             UAC prompt was cancelled or could not be displayed.\n\
+             Please accept the UAC prompt to continue."
+        ));
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    Err(anyhow::anyhow!(
+        "'{cmd}' failed with exit code {code}.\n\
+         Command: {cmd} {arg_list}\n\
+         {stderr}",
+        stderr = stderr.trim()
+    ))
+}
+
+/// Run an nssm command, auto-elevating via UAC if needed.
+/// For start/restart: verifies the service is actually running afterwards.
+pub fn nssm_runas_or_direct(service_name: &str, nssm_args: &[&str]) -> Result<String> {
+    let op = nssm_args.first().copied().unwrap_or("");
+    if is_elevated() {
+        let output = std::process::Command::new(nssm_bin())
+            .args(nssm_args)
+            .output()?;
+        if output.status.success() {
+            return Ok(stringify_output(output));
+        }
+        return Err(anyhow::anyhow!("{}", stringify_output(output)));
+    }
+    runas(nssm_bin(), nssm_args)?;
+    // After the elevated operation, query status (no elevation needed)
+    let status = nssm_status(service_name);
+    // For start/restart, the service must be running
+    if (op == "start" || op == "restart") && status != "active" {
+        return Err(anyhow::anyhow!(
+            "Service started but stopped immediately (status: {status}).\n\
+             Check the core's config or run status check for details."
+        ));
+    }
+    // For stop, the service should be stopped
+    if op == "stop" && status != "inactive" {
+        return Err(anyhow::anyhow!(
+            "Service stop command completed but status is still: {status}."
+        ));
+    }
+    Ok(format!("{op}: {status}"))
 }
 
 // ============================================================================

--- a/src/functions/command/windows.rs
+++ b/src/functions/command/windows.rs
@@ -55,8 +55,8 @@ pub(super) fn stringify_output(output: std::process::Output) -> String {
 // nssm CLI service operations
 // ============================================================================
 
-use crate::config::CoreType;
 use crate::config::CONFIG;
+use crate::config::CoreType;
 
 fn nssm_bin() -> &'static str {
     "nssm"
@@ -135,7 +135,7 @@ pub fn nssm_launch_args(ct: CoreType) -> Vec<String> {
 pub fn is_elevated() -> bool {
     use windows::Win32::Foundation::{CloseHandle, HANDLE};
     use windows::Win32::Security::{
-        GetTokenInformation, TokenElevation, TOKEN_ELEVATION, TOKEN_QUERY,
+        GetTokenInformation, TOKEN_ELEVATION, TOKEN_QUERY, TokenElevation,
     };
     use windows::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
 
@@ -240,8 +240,7 @@ pub fn nssm_runas_or_direct(service_name: &str, nssm_args: &[&str]) -> Result<St
 // System proxy toggle (Windows registry)
 // ============================================================================
 
-const PROXY_REG_PATH: &str =
-    r"Software\Microsoft\Windows\CurrentVersion\Internet Settings";
+const PROXY_REG_PATH: &str = r"Software\Microsoft\Windows\CurrentVersion\Internet Settings";
 
 /// Returns true if the system proxy is currently enabled.
 pub fn get_system_proxy_state() -> Result<bool> {
@@ -291,7 +290,7 @@ pub fn disable_system_proxy() -> Result<()> {
 fn broadcast_settings_change() {
     use windows::Win32::Foundation::{LPARAM, WPARAM};
     use windows::Win32::UI::WindowsAndMessaging::{
-        HWND_BROADCAST, SendMessageTimeoutW, SMTO_ABORTIFHUNG, WM_SETTINGCHANGE,
+        HWND_BROADCAST, SMTO_ABORTIFHUNG, SendMessageTimeoutW, WM_SETTINGCHANGE,
     };
     let _ = unsafe {
         SendMessageTimeoutW(
@@ -309,16 +308,12 @@ fn broadcast_settings_change() {
 /// Retrieve the mixed inbound port from the core REST API (`GET /configs`).
 pub fn get_mixed_port() -> Result<u16> {
     use crate::functions::restful::config_struct::ClashConfig;
-    let resp = minreq::get(format!(
-        "{}/configs",
-        CONFIG.controller_for_core()
-    ))
-    .with_timeout(5)
-    .send()
-    .map_err(|e| anyhow::anyhow!("Failed to fetch /configs: {e}"))?;
-    let cfg: ClashConfig =
-        serde_json::from_str(resp.as_str().map_err(|e| anyhow::anyhow!("{e}"))?)
-            .map_err(|e| anyhow::anyhow!("Failed to parse /configs: {e}"))?;
+    let resp = minreq::get(format!("{}/configs", CONFIG.controller_for_core()))
+        .with_timeout(5)
+        .send()
+        .map_err(|e| anyhow::anyhow!("Failed to fetch /configs: {e}"))?;
+    let cfg: ClashConfig = serde_json::from_str(resp.as_str().map_err(|e| anyhow::anyhow!("{e}"))?)
+        .map_err(|e| anyhow::anyhow!("Failed to parse /configs: {e}"))?;
     cfg.mixed_port
         .or(cfg.port)
         .ok_or_else(|| anyhow::anyhow!("No mixed_port or port found in /configs"))

--- a/src/functions/file/profile.rs
+++ b/src/functions/file/profile.rs
@@ -133,48 +133,53 @@ pub struct UpdateResult {
 pub async fn update_profile(profile: Profile, with_proxy: bool) -> anyhow::Result<UpdateResult> {
     use super::template::fetch_net_resource_statuses;
 
-    // Template profiles re-generate from template + subscriptions
-    if matches!(profile.dtype, ProfileType::Template { .. }) {
-        return update_template_profile(profile, with_proxy).await;
-    }
-
-    // sing-box local imports always use JSON; URL profiles follow current core type
-    if matches!(profile.dtype, ProfileType::Singbox)
+    let result = if matches!(profile.dtype, ProfileType::Template { .. }) {
+        update_template_profile(profile.clone(), with_proxy).await
+    } else if matches!(profile.dtype, ProfileType::Singbox)
         || crate::config::CONFIG.core_type() == crate::config::CoreType::Singbox
     {
-        return update_singbox_profile(profile, with_proxy).await;
-    }
+        update_singbox_profile(profile.clone(), with_proxy).await
+    } else {
+        let path = PROFILE_YAMLS_PATH.join(format!("{}.yaml", &profile.name));
 
-    let path = PROFILE_YAMLS_PATH.join(format!("{}.yaml", &profile.name));
-
-    if let ProfileType::Url(ref url) = profile.dtype {
-        let mut response = crate::functions::restful::download::profile(url, with_proxy)?;
-        let content: serde_yml::Mapping = serde_yml::from_reader(&mut response)
-            .map_err(|e| anyhow::anyhow!("Failed to parse downloaded profile YAML: {e}"))?;
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)?;
+        if let ProfileType::Url(ref url) = profile.dtype {
+            let mut response = crate::functions::restful::download::profile(url, with_proxy)?;
+            let content: serde_yml::Mapping = serde_yml::from_reader(&mut response)
+                .map_err(|e| anyhow::anyhow!("Failed to parse downloaded profile YAML: {e}"))?;
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            serde_yml::to_writer(std::fs::File::create(&path)?, &content)?;
         }
+
+        anyhow::ensure!(
+            path.exists(),
+            "Profile file not found: {}. Download it first.",
+            path.display()
+        );
+
+        let content: serde_yml::Mapping = {
+            let file = std::fs::File::open(&path)?;
+            serde_yml::from_reader(file)
+                .map_err(|e| anyhow::anyhow!("Failed to read profile YAML: {e}"))?
+        };
+
+        let net_updates = fetch_net_resource_statuses(&content, with_proxy).await;
         serde_yml::to_writer(std::fs::File::create(&path)?, &content)?;
-    }
-
-    anyhow::ensure!(
-        path.exists(),
-        "Profile file not found: {}. Download it first.",
-        path.display()
-    );
-
-    let content: serde_yml::Mapping = {
-        let file = std::fs::File::open(&path)?;
-        serde_yml::from_reader(file)
-            .map_err(|e| anyhow::anyhow!("Failed to read profile YAML: {e}"))?
+        Ok(UpdateResult {
+            name: profile.name.clone(),
+            net_updates,
+        })
     };
 
-    let net_updates = fetch_net_resource_statuses(&content, with_proxy).await;
-    serde_yml::to_writer(std::fs::File::create(&path)?, &content)?;
-    Ok(UpdateResult {
-        name: profile.name,
-        net_updates,
-    })
+    if result.is_ok() {
+        let cur = db::get_current();
+        if cur.name == profile.name {
+            let _ = select(profile).await;
+        }
+    }
+
+    result
 }
 
 async fn update_singbox_profile(
@@ -406,13 +411,6 @@ async fn update_template_profile(
                 failures.join("\n")
             );
         }
-    }
-
-    // If the updated profile is the currently active profile, re-select
-    // so the core reloads with the newly downloaded proxy-provider files.
-    let cur = db::get_current();
-    if cur.name == profile.name {
-        let _ = select(profile.clone()).await;
     }
 
     Ok(UpdateResult {

--- a/src/functions/file/profile.rs
+++ b/src/functions/file/profile.rs
@@ -226,7 +226,9 @@ async fn update_template_profile(
     profile: Profile,
     with_proxy: bool,
 ) -> anyhow::Result<UpdateResult> {
-    use crate::functions::file::net_resource::{ExtractNetResources, NetResourceUpdate, ResourceSection};
+    use crate::functions::file::net_resource::{
+        ExtractNetResources, NetResourceUpdate, ResourceSection,
+    };
 
     let template = match &profile.dtype {
         ProfileType::Template { template } => template.clone(),
@@ -766,18 +768,25 @@ proxy-groups:
 "#;
 
         let mut providers = BTreeMap::new();
-        providers.insert("pvd0".to_string(), "https://example.com/sub1.yaml".to_string());
+        providers.insert(
+            "pvd0".to_string(),
+            "https://example.com/sub1.yaml".to_string(),
+        );
         let mut groups = ProxyProviderGroups::new();
         groups.insert("pvd".to_string(), providers);
 
         let urls = collect_proxy_provider_urls(profile_yaml, &groups);
 
         // Group provider (pvd0) should be included
-        assert!(urls.iter().any(|(name, _)| name == "pvd0"),
-            "pvd0 from groups should be collected");
+        assert!(
+            urls.iter().any(|(name, _)| name == "pvd0"),
+            "pvd0 from groups should be collected"
+        );
         // Standalone provider (bak) should also be collected
-        assert!(urls.iter().any(|(name, _)| name == "bak"),
-            "bak standalone provider should be collected");
+        assert!(
+            urls.iter().any(|(name, _)| name == "bak"),
+            "bak standalone provider should be collected"
+        );
 
         // pvd0 should appear only once (not duplicated from extract)
         let pvd0_count = urls.iter().filter(|(name, _)| name == "pvd0").count();
@@ -814,23 +823,41 @@ proxy-groups:
 "#;
 
         let mut pvd_providers = BTreeMap::new();
-        pvd_providers.insert("hajimi".to_string(), "https://hajimi.nvimy.com/file/clash.yaml".to_string());
-        pvd_providers.insert("mojie".to_string(), "https://hajimi.nvimy.com/file/clash_mojie.yaml".to_string());
+        pvd_providers.insert(
+            "hajimi".to_string(),
+            "https://hajimi.nvimy.com/file/clash.yaml".to_string(),
+        );
+        pvd_providers.insert(
+            "mojie".to_string(),
+            "https://hajimi.nvimy.com/file/clash_mojie.yaml".to_string(),
+        );
         let mut groups = ProxyProviderGroups::new();
         groups.insert("pvd".to_string(), pvd_providers);
 
         let urls = collect_proxy_provider_urls(profile_yaml, &groups);
 
-        assert_eq!(urls.len(), 3, "should collect 3 unique URLs: hajimi, mojie, bak");
+        assert_eq!(
+            urls.len(),
+            3,
+            "should collect 3 unique URLs: hajimi, mojie, bak"
+        );
 
         assert!(urls.iter().any(|(name, _)| name == "hajimi"));
         assert!(urls.iter().any(|(name, _)| name == "mojie"));
-        assert!(urls.iter().any(|(name, _)| name == "bak"),
-            "bak MUST be collected as standalone provider");
+        assert!(
+            urls.iter().any(|(name, _)| name == "bak"),
+            "bak MUST be collected as standalone provider"
+        );
 
         // Verify bak's URL is correct
-        let bak_url = urls.iter().find(|(name, _)| name == "bak").map(|(_, url)| url);
-        assert_eq!(bak_url, Some(&"https://hajimi.nvimy.com/file/mojie_johan.yaml".to_string()));
+        let bak_url = urls
+            .iter()
+            .find(|(name, _)| name == "bak")
+            .map(|(_, url)| url);
+        assert_eq!(
+            bak_url,
+            Some(&"https://hajimi.nvimy.com/file/mojie_johan.yaml".to_string())
+        );
     }
 
     #[test]
@@ -873,8 +900,14 @@ proxy-groups:
       - pvd1
 "#;
         let mut providers = BTreeMap::new();
-        providers.insert("pvd0".to_string(), "https://example.com/sub1.yaml".to_string());
-        providers.insert("pvd1".to_string(), "https://example.com/sub2.yaml".to_string());
+        providers.insert(
+            "pvd0".to_string(),
+            "https://example.com/sub1.yaml".to_string(),
+        );
+        providers.insert(
+            "pvd1".to_string(),
+            "https://example.com/sub2.yaml".to_string(),
+        );
         let mut groups = ProxyProviderGroups::new();
         groups.insert("pvd".to_string(), providers);
 

--- a/src/functions/file/template/version1.rs
+++ b/src/functions/file/template/version1.rs
@@ -640,17 +640,32 @@ proxy-groups:
             .and_then(|v| v.as_mapping())
             .unwrap();
         let keys: Vec<&str> = providers.keys().filter_map(|k| k.as_str()).collect();
-        assert!(keys.contains(&"pvd0"), "Expected pvd0 in proxy-providers, got: {keys:?}");
-        assert!(keys.contains(&"bak"), "Expected bak in proxy-providers, got: {keys:?}");
+        assert!(
+            keys.contains(&"pvd0"),
+            "Expected pvd0 in proxy-providers, got: {keys:?}"
+        );
+        assert!(
+            keys.contains(&"bak"),
+            "Expected bak in proxy-providers, got: {keys:?}"
+        );
 
         // Verify << key has been flattened (interval and health-check at top level)
         let bak = providers.get("bak").unwrap().as_mapping().unwrap();
         assert!(bak.get("<<").is_none(), "<< key should be removed from bak");
-        assert!(bak.get("interval").is_some(), "interval should be at top level after merge flatten");
-        assert!(bak.get("health-check").is_some(), "health-check should be at top level after merge flatten");
+        assert!(
+            bak.get("interval").is_some(),
+            "interval should be at top level after merge flatten"
+        );
+        assert!(
+            bak.get("health-check").is_some(),
+            "health-check should be at top level after merge flatten"
+        );
 
         // Verify proxy-anchor section has been stripped
-        assert!(result.get("proxy-anchor").is_none(), "proxy-anchor should be removed from output");
+        assert!(
+            result.get("proxy-anchor").is_none(),
+            "proxy-anchor should be removed from output"
+        );
 
         // Check TestGroup has bak in use
         let groups_seq = result
@@ -730,24 +745,43 @@ proxy-groups:
         let result = gen_template_with_urls(tpl, "user_tpl", &groups).unwrap();
 
         // Verify no << keys anywhere in proxy-providers or proxy-groups
-        let providers = result.get(PROXY_PROVIDERS).and_then(|v| v.as_mapping()).unwrap();
+        let providers = result
+            .get(PROXY_PROVIDERS)
+            .and_then(|v| v.as_mapping())
+            .unwrap();
         for (k, v) in providers {
             let m = v.as_mapping().unwrap();
-            assert!(m.get("<<").is_none(), "provider {k:?} should not have << key");
+            assert!(
+                m.get("<<").is_none(),
+                "provider {k:?} should not have << key"
+            );
         }
 
-        let groups_seq = result.get(PROXY_GROUPS).and_then(|v| v.as_sequence()).unwrap();
+        let groups_seq = result
+            .get(PROXY_GROUPS)
+            .and_then(|v| v.as_sequence())
+            .unwrap();
         for g in groups_seq {
             let m = g.as_mapping().unwrap();
-            assert!(m.get("<<").is_none(), "group {:?} should not have << key", m.get("name"));
+            assert!(
+                m.get("<<").is_none(),
+                "group {:?} should not have << key",
+                m.get("name")
+            );
         }
 
         // Verify proxy-anchor is stripped
-        assert!(result.get("proxy-anchor").is_none(), "proxy-anchor should be removed");
+        assert!(
+            result.get("proxy-anchor").is_none(),
+            "proxy-anchor should be removed"
+        );
 
         // bak must be in proxy-providers
         let keys: Vec<&str> = providers.keys().filter_map(|k| k.as_str()).collect();
-        assert!(keys.contains(&"bak"), "Expected bak in proxy-providers, got: {keys:?}");
+        assert!(
+            keys.contains(&"bak"),
+            "Expected bak in proxy-providers, got: {keys:?}"
+        );
 
         // SpecialGroup must use bak
         let special = groups_seq
@@ -761,7 +795,10 @@ proxy-groups:
             .iter()
             .filter_map(|v| v.as_str())
             .collect();
-        assert!(uses.contains(&"bak"), "SpecialGroup use should contain bak, got: {uses:?}");
+        assert!(
+            uses.contains(&"bak"),
+            "SpecialGroup use should contain bak, got: {uses:?}"
+        );
     }
 
     #[test]
@@ -805,8 +842,14 @@ proxy-groups:
             .and_then(|v| v.as_mapping())
             .unwrap();
         let keys: Vec<&str> = providers.keys().filter_map(|k| k.as_str()).collect();
-        assert!(keys.contains(&"pvd0"), "Expected pvd0 in proxy-providers, got: {keys:?}");
-        assert!(keys.contains(&"bak"), "Expected bak in proxy-providers, got: {keys:?}");
+        assert!(
+            keys.contains(&"pvd0"),
+            "Expected pvd0 in proxy-providers, got: {keys:?}"
+        );
+        assert!(
+            keys.contains(&"bak"),
+            "Expected bak in proxy-providers, got: {keys:?}"
+        );
 
         // Check proxy-groups section contains TestGroup with bak in use list
         let groups_seq = result

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -38,10 +38,10 @@ static GLOBAL_CHORD_SHORTCUTS: LazyLock<Vec<(KeyCombo, &str)>> = LazyLock::new(|
         }
     }
     vec![
-        (KeyCombo(vec![ctrl('g'), plain('c')]), "Open app config dir"),
+        (KeyCombo(vec![ctrl('g'), plain('c')]), "Open core data dir"),
         (
             KeyCombo(vec![ctrl('g'), plain('m')]),
-            "Open clash config dir",
+            "Open core install dir",
         ),
         (KeyCombo(vec![ctrl('g'), plain('f')]), "Start core service"),
         (
@@ -209,13 +209,13 @@ impl App {
                     log::debug!("global_chord dispatch: {seq:?}");
                     match seq.last().and_then(|k| k.plain()) {
                         Some('c') => {
-                            log::debug!("open_dir: config dir");
-                            let _ = crate::functions::command::open_dir(
-                                crate::config::config_root_path().to_str().unwrap(),
-                            );
+                            log::debug!("open_dir: core data dir");
+                            let dir =
+                                crate::config::core_data_dir(crate::config::CONFIG.core_type());
+                            let _ = crate::functions::command::open_dir(dir.to_str().unwrap());
                         }
                         Some('m') => {
-                            log::debug!("open_dir: clash config dir");
+                            log::debug!("open_dir: core install dir");
                             let dir_str = match crate::config::CONFIG.core_type() {
                                 crate::config::CoreType::Mihomo => {
                                     &crate::config::CONFIG.cfg_file.mihomo.core.config_dir
@@ -224,7 +224,10 @@ impl App {
                                     &crate::config::CONFIG.cfg_file.singbox.core.config_dir
                                 }
                             };
-                            let _ = crate::functions::command::open_dir(dir_str);
+                            let parent = std::path::Path::new(dir_str)
+                                .parent()
+                                .unwrap_or(std::path::Path::new(dir_str));
+                            let _ = crate::functions::command::open_dir(parent.to_str().unwrap());
                         }
                         Some('f') => {
                             log::debug!("restart core service");

--- a/src/tui/tab/srvctl.rs
+++ b/src/tui/tab/srvctl.rs
@@ -69,6 +69,12 @@ enum SrvCtlOp {
     Restart,
     SwitchCore,
     StopAll,
+    #[cfg(windows)]
+    Install,
+    #[cfg(windows)]
+    Uninstall,
+    #[cfg(windows)]
+    ToggleSysProxy,
 }
 
 impl SrvCtlOp {
@@ -78,10 +84,23 @@ impl SrvCtlOp {
             Self::Restart => "Start Service",
             Self::SwitchCore => "Switch Core",
             Self::StopAll => "Stop All Services",
+            #[cfg(windows)]
+            Self::Install => "Install Srv",
+            #[cfg(windows)]
+            Self::Uninstall => "Uninstall Srv",
+            #[cfg(windows)]
+            Self::ToggleSysProxy => "Toggle SysProxy",
         }
     }
     fn all() -> Vec<Self> {
-        vec![Self::Stop, Self::Restart, Self::SwitchCore, Self::StopAll]
+        let mut ops = vec![Self::Stop, Self::Restart, Self::SwitchCore, Self::StopAll];
+        #[cfg(windows)]
+        {
+            ops.push(Self::Install);
+            ops.push(Self::Uninstall);
+            ops.push(Self::ToggleSysProxy);
+        }
+        ops
     }
 }
 
@@ -99,6 +118,8 @@ struct SrvCtlContent {
     singbox_service_name: String,
     mihomo_is_user: bool,
     singbox_is_user: bool,
+    #[cfg(windows)]
+    proxy_enabled: bool,
 }
 
 impl SrvCtlContent {
@@ -111,6 +132,10 @@ impl SrvCtlContent {
         async move {
             let status = match controller {
                 crate::config::ServiceController::Launchd => launchd_status(&service_name, is_user),
+                #[cfg(windows)]
+                crate::config::ServiceController::Nssm => {
+                    crate::functions::command::nssm_status(&service_name)
+                }
                 _ => {
                     let mut args = vec!["is-active"];
                     if is_user {
@@ -138,6 +163,10 @@ impl SrvCtlContent {
         async move {
             let status = match controller {
                 crate::config::ServiceController::Launchd => launchd_status(&service_name, is_user),
+                #[cfg(windows)]
+                crate::config::ServiceController::Nssm => {
+                    crate::functions::command::nssm_status(&service_name)
+                }
                 _ => {
                     let mut args = vec!["is-active"];
                     if is_user {
@@ -266,6 +295,11 @@ impl TabContent for SrvCtlContent {
         self.status = "...".to_owned();
         self.mihomo_status = "...".to_owned();
         self.singbox_status = "...".to_owned();
+        #[cfg(windows)]
+        {
+            self.proxy_enabled = crate::functions::command::get_system_proxy_state()
+                .unwrap_or(false);
+        }
         if !self.ops.is_empty() {
             state.select(Some(0));
         }
@@ -445,6 +479,55 @@ impl TabContent for SrvCtlContent {
                                 }
                             }
                         }
+                        #[cfg(windows)]
+                        SrvCtlOp::Install => {
+                            handle!(
+                                crate::functions::command::install_core_service(
+                                    pw_ref,
+                                    crate::config::CONFIG.core_type(),
+                                ),
+                                "installed"
+                            )
+                        }
+                        #[cfg(windows)]
+                        SrvCtlOp::Uninstall => {
+                            handle!(
+                                crate::functions::command::uninstall_core_service(
+                                    pw_ref,
+                                    crate::config::CONFIG.core_type(),
+                                ),
+                                "uninstalled"
+                            )
+                        }
+                        #[cfg(windows)]
+                        SrvCtlOp::ToggleSysProxy => {
+                            let result = async {
+                                let enabled = crate::functions::command::get_system_proxy_state()?;
+                                if enabled {
+                                    crate::functions::command::disable_system_proxy()?;
+                                    Ok::<bool, anyhow::Error>(false)
+                                } else {
+                                    let port = crate::functions::command::get_mixed_port()?;
+                                    crate::functions::command::enable_system_proxy(port)?;
+                                    Ok::<bool, anyhow::Error>(true)
+                                }
+                            };
+                            match result.await {
+                                Ok(new_state) => {
+                                    let label = if new_state { "enabled" } else { "disabled" };
+                                    crate::tui::widget::popmsg::Confirm::title("OK".to_owned())
+                                        .with_prompt(format!("System proxy {label}"))
+                                        .build_and_send();
+                                    wrapper(move |c: &mut SrvCtlContent| {
+                                        c.proxy_enabled = new_state;
+                                    })
+                                }
+                                Err(e) => {
+                                    crate::tui::widget::popmsg::Confirm::err(e);
+                                    do_nothing()
+                                }
+                            }
+                        }
                     }
                 }
                 .spawn_at(task_set);
@@ -481,17 +564,25 @@ impl TabContent for SrvCtlContent {
             }
         );
 
+        #[cfg(windows)]
+        let proxy_label = format!(
+            "  Proxy: {}",
+            if self.proxy_enabled { "ON" } else { "OFF" }
+        );
+
+        let title_line = format!(
+            "{} — {} (core: {}){}",
+            Self::TITLE,
+            self.service_name,
+            self.core_label,
+            user_tag
+        );
+
         let block = Block::bordered()
             .border_style(section.border)
-            .title(format!(
-                "{} — {} (core: {}){}",
-                Self::TITLE,
-                self.service_name,
-                self.core_label,
-                user_tag
-            ))
-            .title_bottom(
-                ratatui::text::Line::from(vec![
+            .title(title_line)
+            .title_bottom({
+                let mut spans = vec![
                     ratatui::text::Span::styled(
                         format!(" {} ", current_core_label),
                         section.border,
@@ -500,9 +591,14 @@ impl TabContent for SrvCtlContent {
                         format!(" {} ", other_core_label),
                         section.border.fg(Color::Rgb(100, 100, 100)),
                     ),
-                ])
-                .right_aligned(),
-            );
+                ];
+                #[cfg(windows)]
+                spans.push(ratatui::text::Span::styled(
+                    format!(" {} ", proxy_label),
+                    section.border.fg(Color::Rgb(100, 100, 100)),
+                ));
+                ratatui::text::Line::from(spans).right_aligned()
+            });
 
         let items: Vec<ListItem> = self
             .ops

--- a/src/tui/tab/srvctl.rs
+++ b/src/tui/tab/srvctl.rs
@@ -297,8 +297,8 @@ impl TabContent for SrvCtlContent {
         self.singbox_status = "...".to_owned();
         #[cfg(windows)]
         {
-            self.proxy_enabled = crate::functions::command::get_system_proxy_state()
-                .unwrap_or(false);
+            self.proxy_enabled =
+                crate::functions::command::get_system_proxy_state().unwrap_or(false);
         }
         if !self.ops.is_empty() {
             state.select(Some(0));
@@ -565,10 +565,7 @@ impl TabContent for SrvCtlContent {
         );
 
         #[cfg(windows)]
-        let proxy_label = format!(
-            "  Proxy: {}",
-            if self.proxy_enabled { "ON" } else { "OFF" }
-        );
+        let proxy_label = format!("  Proxy: {}", if self.proxy_enabled { "ON" } else { "OFF" });
 
         let title_line = format!(
             "{} — {} (core: {}){}",

--- a/src/tui/tab/status.rs
+++ b/src/tui/tab/status.rs
@@ -104,61 +104,52 @@ impl BasicTabContent for Status {
     fn on_enter(&mut self, task_set: &mut FutureSet<Self>, _state: &mut Self::State) {
         self.paused = false;
 
-        // Synchronous detection so other tabs see the flag before their first fetch
         let was_unknown = self.detected_core_type.is_none();
-        match restful::core_detect::detect_core_type() {
-            Ok(detected) => {
-                let configured = CONFIG.core_type();
-                self.detected_core_type = Some(detected);
-                let mismatch = detected != configured;
-                crate::config::set_core_mismatch(mismatch);
-                if mismatch {
-                    let msg =
-                        format!("API returned {detected} data, but {configured} is configured");
-                    self.error = Some(msg.clone());
-                    if was_unknown {
-                        crate::tui::widget::popmsg::Confirm::err(msg);
-                    }
+        if was_unknown {
+            match crate::functions::command::is_core_service_running() {
+                Some(false) => {
+                    self.error = Some("Core service is not running".to_owned());
+                    return;
+                }
+                _ => {
+                    self.error = Some("Detecting...".to_owned());
                 }
             }
-            Err(e) => {
-                self.error = Some(format!("Core detection failed: {e}"));
-            }
-        }
-
-        if crate::config::is_core_mismatch() {
-            return;
         }
 
         async {
+            let detected = tri!(
+                tokio::task::spawn_blocking(restful::core_detect::detect_core_type)
+                    .await
+                    .unwrap(),
+                or_set
+            );
             let version = tri!(
                 tokio::task::spawn_blocking(restful::control::version)
                     .await
-                    .unwrap()
+                    .unwrap(),
+                or_set
             );
             let config = tri!(
                 tokio::task::spawn_blocking(restful::config::fetch)
                     .await
-                    .unwrap()
-            );
-            let detected = tri!(
-                tokio::task::spawn_blocking(restful::core_detect::detect_core_type)
-                    .await
-                    .unwrap()
+                    .unwrap(),
+                or_set
             );
 
             wrapper(move |content: &mut Self| {
                 let configured = CONFIG.core_type();
                 content.detected_core_type = Some(detected);
-                if detected == configured {
+                let mismatch = detected != configured;
+                crate::config::set_core_mismatch(mismatch);
+                if mismatch {
+                    let msg =
+                        format!("API returned {detected} data, but {configured} is configured");
+                    content.error = Some(msg);
+                } else {
                     content.version = Some(version);
                     content.config = Some(config);
-                    crate::config::set_core_mismatch(false);
-                } else {
-                    content.error = Some(format!(
-                        "API returned {detected} data, but {configured} is configured"
-                    ));
-                    crate::config::set_core_mismatch(true);
+                    content.error = None;
                 }
             })
         }

--- a/src/tui/term.rs
+++ b/src/tui/term.rs
@@ -6,19 +6,24 @@ use super::utils::raw_mode;
 static CSI_U_ENABLED: AtomicBool = AtomicBool::new(false);
 
 fn probe() {
-    let mut stdout = std::io::stdout().lock();
-    let _ = write!(stdout, "\x1b[?u");
-    let _ = stdout.flush();
-    drop(stdout);
+    // CSI-u (kitty keyboard protocol) probe — only meaningful on Unix TTYs.
+    // On Windows, raw mode stdin reads block until a keypress, so skip entirely.
+    #[cfg(unix)]
+    {
+        let mut stdout = std::io::stdout().lock();
+        let _ = write!(stdout, "\x1b[?u");
+        let _ = stdout.flush();
+        drop(stdout);
 
-    std::thread::sleep(std::time::Duration::from_millis(50));
+        std::thread::sleep(std::time::Duration::from_millis(50));
 
-    use std::io::Read;
-    let mut stdin = std::io::stdin().lock();
-    let mut buf = [0u8; 32];
-    if let Ok(n) = stdin.read(&mut buf) {
-        if n > 0 && buf[..n].windows(5).any(|w| w == b"\x1b[?0u") {
-            CSI_U_ENABLED.store(true, Ordering::Relaxed);
+        use std::io::Read;
+        let mut stdin = std::io::stdin().lock();
+        let mut buf = [0u8; 32];
+        if let Ok(n) = stdin.read(&mut buf) {
+            if n > 0 && buf[..n].windows(5).any(|w| w == b"\x1b[?0u") {
+                CSI_U_ENABLED.store(true, Ordering::Relaxed);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds Windows platform support and several quality-of-life improvements.

### Windows Support
- Platform-aware `edit`/`open` commands with native Windows fallbacks (`notepad`, `explorer`)
- New `install.ps1` PowerShell install script
- Windows-specific command module (`src/functions/command/windows.rs`) for service management via `nssm`
- `winreg` and `windows` crate dependencies for registry and system integration
- Platform-conditional compilation guards throughout

### Bug Fixes
- Eliminate startup hangs on Windows (cargo run blocking until keypress/Ctrl-C)
- Fix permission-related issues
- Platform-aware shell spawn with empty-command fallback

### Profile Improvements
- **Re-select current profile after any update** — previously only template profiles re-selected after update; now all profile types (URL, Singbox, Template) re-select when the updated profile is the active one, covering TUI single update, update-all, and CLI `profile update`
- Ctrl+G C/M chord shortcuts now target core-specific directories:
  - **Ctrl+G C** opens the core data directory (e.g. `~/.config/clashtui/mihomo` or `~/.config/clashtui/sing-box`)
  - **Ctrl+G M** opens the core install root directory (e.g. `/opt/clashtui/mihomo` or `/opt/clashtui/sing-box`)

### Tests
- Added tests for `core_data_dir()` routing and core install directory resolution
- Added platform-aware command tests

### Files Changed
`src/functions/command/`, `src/functions/file/profile.rs`, `src/tui/app.rs`, `src/tui/tab/srvctl.rs`, `src/tui/term.rs`, `src/config/`, `Cargo.toml`, `install.ps1`, docs