### PR TITLE
Improvment/mihomo template

### DIFF
--- a/contrib/templates/mihomo/generic_tpl_with_ruleset.yaml
+++ b/contrib/templates/mihomo/generic_tpl_with_ruleset.yaml
@@ -44,103 +44,83 @@ rule-providers:
   private:
     url: "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/meta/geo/geosite/private.yaml"
     type: http
-    path: ./rule-providers/geosite/private.yaml
     <<: *ra_domain
   cn_domain:
     url: "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/meta/geo/geosite/cn.yaml"
     type: http
-    path: ./rule-providers/geosite/cn.yaml
     <<: *ra_domain
   biliintl_domain:
     url: "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/meta/geo/geosite/biliintl.yaml"
     type: http
-    path: ./rule-providers/geosite/biliintl.yaml
     <<: *ra_domain
   ehentai_domain:
     url: "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/meta/geo/geosite/ehentai.yaml"
     type: http
-    path: ./rule-providers/geosite/ehentai.yaml
     <<: *ra_domain
   github_domain:
     url: "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/meta/geo/geosite/github.yaml"
     type: http
-    path: ./rule-providers/geosite/github.yaml
     <<: *ra_domain
   twitter_domain:
     url: "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/meta/geo/geosite/twitter.yaml"
     type: http
-    path: ./rule-providers/geosite/twitter.yaml
     <<: *ra_domain
   youtube_domain:
     url: "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/meta/geo/geosite/youtube.yaml"
     type: http
-    path: ./rule-providers/geosite/youtube.yaml
     <<: *ra_domain
   google_domain:
     url: "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/meta/geo/geosite/google.yaml"
     type: http
-    path: ./rule-providers/geosite/google.yaml
     <<: *ra_domain
   telegram_domain:
     url: "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/meta/geo/geosite/telegram.yaml"
     type: http
-    path: ./rule-providers/geosite/telegram.yaml
     <<: *ra_domain
   netflix_domain:
     url: "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/meta/geo/geosite/netflix.yaml"
     type: http
-    path: ./rule-providers/geosite/netflix.yaml
     <<: *ra_domain
   bilibili_domain:
     url: "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/meta/geo/geosite/bilibili.yaml"
     type: http
-    path: ./rule-providers/geosite/bilibili.yaml
     <<: *ra_domain
   bahamut_domain:
     url: "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/meta/geo/geosite/bahamut.yaml"
     type: http
-    path: ./rule-providers/geosite/bahamut.yaml
     <<: *ra_domain
   spotify_domain:
     url: "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/meta/geo/geosite/spotify.yaml"
     type: http
-    path: ./rule-providers/geosite/spotify.yaml
     <<: *ra_domain
   pixiv_domain:
     url: "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/meta/geo/geosite/pixiv.yaml"
     type: http
-    path: ./rule-providers/geosite/pixiv.yaml
     <<: *ra_domain
   geolocation-!cn:
     url: "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/meta/geo/geosite/geolocation-!cn.yaml"
     type: http
-    path: ./rule-providers/geosite/geolocation-notcn.yaml
     <<: *ra_domain
 
   cn_ip:
     url: "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/meta/geo/geoip/cn.yaml"
     type: http
-    path: ./rule-providers/geoip/cn.yaml
     <<: *ra_ip
   google_ip:
     url: "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/meta/geo/geoip/google.yaml"
     type: http
-    path: ./rule-providers/geoip/google.yaml
     <<: *ra_ip
   netflix_ip:
     url: "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/meta/geo/geoip/netflix.yaml"
     type: http
-    path: ./rule-providers/geoip/netflix.yaml
     <<: *ra_ip
   twitter_ip:
     url: "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/meta/geo/geoip/twitter.yaml"
     type: http
-    path: ./rule-providers/geoip/twitter.yaml
     <<: *ra_ip
   telegram_ip:
     url: "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/meta/geo/geoip/telegram.yaml"
     type: http
-    path: ./rule-providers/geoip/telegram.yaml
     <<: *ra_ip
 
 rules:

--- a/docs/clashtui_feature_design_en.md
+++ b/docs/clashtui_feature_design_en.md
@@ -292,7 +292,7 @@ Why not use the API to update Profiles:
 - Because the API does not return values when updating Profiles (you don't know if the update succeeded), so you don't know what needs updating.
 - Therefore, implementing profile updates ourselves provides a better experience.
 
-*When Mihomo proxy-providers and rule-providers don't have a path, the path is set to `<md5 of url>.yaml`. ClashTui needs to support this convention.*
+*When Mihomo proxy-providers and rule-providers don't have a path, the path defaults to `proxies/<md5 of url>`. ClashTui needs to support this convention.*
 
 ## Template Management Design
 
@@ -380,7 +380,7 @@ Proxy-provider expansion:
 
 Because sing-box doesn't support proxy-providers, the Template feature can be used as an alternative:
 - When generating a Template type profile, store the URLs in the profile
-- Proxy-providers also have path info for URL files, e.g.: placed in `~/.config/clashtui/sing-box/proxy-providers/<md5 of url>.yaml`
+- Proxy-providers also have path info for URL files, e.g.: placed in `~/.config/clashtui/sing-box/proxy-providers/<md5 of url>.json`
 - With the above information, the proxy-provider functionality can be replaced.
 
 Template type profile generation:

--- a/docs/clashtui_feature_design_zh.md
+++ b/docs/clashtui_feature_design_zh.md
@@ -291,7 +291,7 @@ File/Url Profile 的选择:
 -   因为通过 api 更新 Profile 并没有返回值 (不知道是否更新成功), 则不知道有哪些东西要更新。
 -   所以自己实现更新 Profile 会有比较好的体验。
 
-*Mihomo 的 proxy-providers 和 rule-providers 没有 path 时, 则 path 会被设置为 `<url 的 md5 的值>.yaml`。ClashTui 需要支持这个设定。*
+*Mihomo 的 proxy-providers 和 rule-providers 没有 path 时, 则 path 默认为 `proxies/<url 的 md5 的值>`。ClashTui 需要支持这个设定。*
 
 ## Template 的管理设计
 
@@ -380,7 +380,7 @@ proxy-provider 的展开:
 
 因为 sing-box 不支持 proxy-providers, 但是可以用 Template 的功能来替代它:
 -   生成 Tempate type profile 时, 将 urls 存放到 profile 中
--   proxy-providers 还有 url 的文件的路径信息, 比如: 放在 `~/.config/clashtui/sing-box/proxy-providers/<url 的 md5 的值>.yaml`。 
+-   proxy-providers 还有 url 的文件的路径信息, 比如: 放在 `~/.config/clashtui/sing-box/proxy-providers/<url 的 md5 的值>.json`。 
 -   有了上面的信息就可以替代 proxy-providers 的功能了。
 
 Template type profile 的生成:

--- a/src/functions/file/net_resource.rs
+++ b/src/functions/file/net_resource.rs
@@ -104,7 +104,10 @@ impl ExtractNetResources for serde_yml::Mapping {
                     .and_then(|v| v.as_str())
                 {
                     Some(s) => s.to_owned(),
-                    None => continue,
+                    None => {
+                        let hash = format!("{:x}", md5::compute(url.as_bytes()));
+                        format!("proxies/{hash}")
+                    }
                 };
 
                 resources.push(NetResource {
@@ -180,8 +183,7 @@ mod tests {
             ResourceSection::ProxyProvider,
             ResourceSection::RuleProvider,
         ]);
-        assert_eq!(resources.len(), 4, "should find 2 PP + 2 RP = 4 resources");
-
+        assert_eq!(resources.len(), 5, "should find 2 PP + 3 RP = 5 resources");
         let pp_count = resources
             .iter()
             .filter(|r| r.section == ResourceSection::ProxyProvider)
@@ -192,7 +194,7 @@ mod tests {
             .iter()
             .filter(|r| r.section == ResourceSection::RuleProvider)
             .count();
-        assert_eq!(rp_count, 2);
+        assert_eq!(rp_count, 3);
     }
 
     #[test]
@@ -209,7 +211,7 @@ mod tests {
     fn filter_rule_providers_only() {
         let yaml = load_test_yaml();
         let resources = yaml.extract(&[ResourceSection::RuleProvider]);
-        assert_eq!(resources.len(), 2);
+        assert_eq!(resources.len(), 3);
         for r in &resources {
             assert_eq!(r.section, ResourceSection::RuleProvider);
         }
@@ -222,7 +224,7 @@ mod tests {
             ResourceSection::ProxyProvider,
             ResourceSection::RuleProvider,
         ]);
-        assert_eq!(resources.len(), 4);
+        assert_eq!(resources.len(), 5);
     }
 
     #[test]

--- a/src/functions/file/profile.rs
+++ b/src/functions/file/profile.rs
@@ -292,7 +292,7 @@ async fn update_template_profile(
     } else {
         let cfg_dir =
             std::path::PathBuf::from(&crate::config::CONFIG.cfg_file.mihomo.core.config_dir);
-        let tpl_name = std::path::Path::new(&template)
+        let _tpl_name = std::path::Path::new(&template)
             .file_stem()
             .and_then(|s| s.to_str())
             .unwrap_or(&template);
@@ -302,7 +302,8 @@ async fn update_template_profile(
             for (name, url) in providers {
                 let url = url.clone();
                 let name = name.clone();
-                let path = cfg_dir.join(format!("proxy-providers/tpl/{}/{}.yaml", tpl_name, &name));
+                let hash = format!("{:x}", md5::compute(url.as_bytes()));
+                let path = cfg_dir.join(format!("proxies/{hash}"));
                 download_handles.push(tokio::task::spawn_blocking(move || {
                     match crate::functions::restful::download::profile(&url, with_proxy) {
                         Ok(mut rdr) => {

--- a/src/functions/file/template.rs
+++ b/src/functions/file/template.rs
@@ -308,7 +308,7 @@ pub fn check_template_ppg_availability(
     }
 
     let is_singbox = crate::config::CONFIG.core_type() == crate::config::CoreType::Singbox;
-    let tpl_name = std::path::Path::new(template)
+    let _tpl_name = std::path::Path::new(template)
         .file_stem()
         .and_then(|s| s.to_str())
         .unwrap_or(template);
@@ -323,7 +323,8 @@ pub fn check_template_ppg_availability(
                 let cfg_dir = std::path::PathBuf::from(
                     &crate::config::CONFIG.cfg_file.mihomo.core.config_dir,
                 );
-                cfg_dir.join(format!("proxy-providers/tpl/{}/{}.yaml", tpl_name, name))
+                let hash = format!("{:x}", md5::compute(url.as_bytes()));
+                cfg_dir.join(format!("proxies/{hash}"))
             };
             if !path.exists() {
                 missing.push(format!("  {name} ({url}) -> {}", path.display()));

--- a/src/functions/file/template/testdata/empty_uses_tpl_output.yaml
+++ b/src/functions/file/template/testdata/empty_uses_tpl_output.yaml
@@ -7,7 +7,6 @@ proxy-providers:
       enable: true
       url: https://www.gstatic.com/generate_204
       interval: 300
-    path: proxy-providers/tpl/empty_uses_tpl/pvd0.yaml
   static:
     type: http
     interval: 3600

--- a/src/functions/file/template/testdata/multi_provider_tpl_output.yaml
+++ b/src/functions/file/template/testdata/multi_provider_tpl_output.yaml
@@ -7,7 +7,6 @@ proxy-providers:
       enable: true
       url: https://www.gstatic.com/generate_204
       interval: 300
-    path: proxy-providers/tpl/multi_provider_tpl/pvd0.yaml
   pvd1:
     type: http
     interval: 3600
@@ -16,7 +15,6 @@ proxy-providers:
       enable: true
       url: https://www.gstatic.com/generate_204
       interval: 300
-    path: proxy-providers/tpl/multi_provider_tpl/pvd1.yaml
   pvd20:
     type: http
     interval: 7200
@@ -25,7 +23,6 @@ proxy-providers:
       enable: true
       url: https://www.gstatic.com/generate_204
       interval: 600
-    path: proxy-providers/tpl/multi_provider_tpl/pvd20.yaml
   pvd21:
     type: http
     interval: 7200
@@ -34,7 +31,6 @@ proxy-providers:
       enable: true
       url: https://www.gstatic.com/generate_204
       interval: 600
-    path: proxy-providers/tpl/multi_provider_tpl/pvd21.yaml
   static:
     type: file
     path: ./proxy-providers/static.yaml

--- a/src/functions/file/template/testdata/simple_tpl_output.yaml
+++ b/src/functions/file/template/testdata/simple_tpl_output.yaml
@@ -7,7 +7,6 @@ proxy-providers:
       enable: true
       url: https://www.gstatic.com/generate_204
       interval: 300
-    path: proxy-providers/tpl/simple_tpl/pvd0.yaml
   static:
     type: http
     interval: 3600

--- a/src/functions/file/template/version1.rs
+++ b/src/functions/file/template/version1.rs
@@ -33,7 +33,7 @@ pub(super) fn gen_template(
 
 pub(super) fn gen_template_with_urls(
     tpl: serde_yml::Mapping,
-    tpl_name: &str,
+    _tpl_name: &str,
     groups: &ProxyProviderGroups,
 ) -> anyhow::Result<serde_yml::Mapping> {
     use std::collections::HashMap;
@@ -72,13 +72,6 @@ pub(super) fn gen_template_with_urls(
                 new_pp.insert(
                     serde_yml::Value::String("url".into()),
                     serde_yml::Value::String(url.clone()),
-                );
-                new_pp.insert(
-                    serde_yml::Value::String("path".into()),
-                    serde_yml::Value::String(format!(
-                        "proxy-providers/tpl/{}/{}.yaml",
-                        tpl_name, the_pp_name
-                    )),
                 );
                 new_proxy_providers.insert(
                     serde_yml::Value::String(the_pp_name),
@@ -534,20 +527,14 @@ mod tests {
             pvd0.get("url").and_then(|v| v.as_str()),
             Some("https://a.example.com/p1.yaml")
         );
-        assert_eq!(
-            pvd0.get("path").and_then(|v| v.as_str()),
-            Some("proxy-providers/tpl/simple_tpl/pvd0.yaml")
-        );
+        assert!(pvd0.get("path").is_none());
 
         let pvd1 = providers.get("pvd1").unwrap().as_mapping().unwrap();
         assert_eq!(
             pvd1.get("url").and_then(|v| v.as_str()),
             Some("https://b.example.com/p2.yaml")
         );
-        assert_eq!(
-            pvd1.get("path").and_then(|v| v.as_str()),
-            Some("proxy-providers/tpl/simple_tpl/pvd1.yaml")
-        );
+        assert!(pvd1.get("path").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Remove explicit `path` fields from mihomo proxy-providers and rule-providers generated by templates. Instead, rely on mihomo default behavior where providers without an explicit `path` use `proxies/<md5 of url>`.

Previously, clashtui hardcoded `path: proxy-providers/tpl/<template>/<name>.yaml` for each provider, which was redundant and inconsistent with mihomo defaults.

## Changes

- **`net_resource.rs`**: When a provider has no `path`, default to `proxies/<md5 hash>` instead of skipping it
- **`profile.rs`**: Download providers to `proxies/<md5 hash>` instead of `proxy-providers/tpl/<template>/<name>.yaml`
- **`template.rs`**: Check for cached files at `proxies/<md5 hash>`
- **`version1.rs`**: Stop injecting explicit `path` into generated proxy-provider entries
- **Template examples**: Remove explicit `path` from all rule-providers in `contrib/templates/mihomo/generic_tpl_with_ruleset.yaml`
- **Docs**: Update mihomo path convention docs (EN/ZH) and fix sing-box extension typo (`.yaml` -> `.json`)
- **Tests**: Updated test data and assertions to match new behavior