### PR TITLE
fix: Flatten YAML merge keys and download standalone proxy-providers

### DIFF
--- a/src/functions/file/profile.rs
+++ b/src/functions/file/profile.rs
@@ -226,7 +226,7 @@ async fn update_template_profile(
     profile: Profile,
     with_proxy: bool,
 ) -> anyhow::Result<UpdateResult> {
-    use crate::functions::file::net_resource::{NetResourceUpdate, ResourceSection};
+    use crate::functions::file::net_resource::{ExtractNetResources, NetResourceUpdate, ResourceSection};
 
     let template = match &profile.dtype {
         ProfileType::Template { template } => template.clone(),
@@ -297,53 +297,77 @@ async fn update_template_profile(
             .and_then(|s| s.to_str())
             .unwrap_or(&template);
 
-        let mut download_handles = Vec::new();
+        // Collect URLs from both proxy-provider groups and standalone providers.
+        // Standalone proxy-providers (with own `url`, no `tpl_param`) are not in
+        // clashtui.proxy_provider_groups but need to be pre-downloaded as well.
+        let mut download_urls: Vec<(String, String)> = Vec::new();
         for providers in groups.values() {
             for (name, url) in providers {
-                let url = url.clone();
-                let name = name.clone();
-                let hash = format!("{:x}", md5::compute(url.as_bytes()));
-                let path = cfg_dir.join(format!("proxies/{hash}"));
-                download_handles.push(tokio::task::spawn_blocking(move || {
-                    match crate::functions::restful::download::profile(&url, with_proxy) {
-                        Ok(mut rdr) => {
-                            let mut buf = Vec::new();
-                            if let Err(e) = std::io::Read::read_to_end(&mut rdr, &mut buf) {
+                download_urls.push((name.clone(), url.clone()));
+            }
+        }
+
+        // Also extract standalone proxy-provider URLs from the generated profile
+        let profile_path = super::PROFILE_YAMLS_PATH.join(format!("{}.yaml", &profile.name));
+        if let Ok(content) = std::fs::read_to_string(&profile_path) {
+            if let Ok(mapping) = serde_yml::from_str::<serde_yml::Mapping>(&content) {
+                for resource in mapping.extract(&[ResourceSection::ProxyProvider]) {
+                    let already_in_groups = groups
+                        .values()
+                        .flat_map(|providers| providers.values())
+                        .any(|url| url == &resource.url);
+                    if !already_in_groups {
+                        download_urls.push((resource.name, resource.url));
+                    }
+                }
+            }
+        }
+
+        let mut download_handles = Vec::new();
+        for (name, url) in download_urls {
+            let url = url.clone();
+            let name = name.clone();
+            let hash = format!("{:x}", md5::compute(url.as_bytes()));
+            let path = cfg_dir.join(format!("proxies/{hash}"));
+            download_handles.push(tokio::task::spawn_blocking(move || {
+                match crate::functions::restful::download::profile(&url, with_proxy) {
+                    Ok(mut rdr) => {
+                        let mut buf = Vec::new();
+                        if let Err(e) = std::io::Read::read_to_end(&mut rdr, &mut buf) {
+                            return (name, url, path, false, Some(e.to_string()));
+                        }
+                        if serde_yml::from_slice::<serde_yml::Mapping>(&buf).is_err() {
+                            return (
+                                name,
+                                url,
+                                path,
+                                false,
+                                Some("Invalid YAML format".to_string()),
+                            );
+                        }
+                        if let Some(parent) = path.parent() {
+                            if let Err(e) = std::fs::create_dir_all(parent) {
                                 return (name, url, path, false, Some(e.to_string()));
                             }
-                            if serde_yml::from_slice::<serde_yml::Mapping>(&buf).is_err() {
-                                return (
-                                    name,
-                                    url,
-                                    path,
-                                    false,
-                                    Some("Invalid YAML format".to_string()),
-                                );
-                            }
-                            if let Some(parent) = path.parent() {
-                                if let Err(e) = std::fs::create_dir_all(parent) {
-                                    return (name, url, path, false, Some(e.to_string()));
-                                }
-                            }
-                            match std::fs::write(&path, &buf) {
-                                Ok(()) => (name, url, path, true, None),
-                                Err(e) => (name, url, path, false, Some(e.to_string())),
-                            }
                         }
-                        Err(e) => {
-                            if path.exists()
-                                && std::fs::read(&path).is_ok_and(|buf| {
-                                    serde_yml::from_slice::<serde_yml::Mapping>(&buf).is_ok()
-                                })
-                            {
-                                (name, url, path, true, None)
-                            } else {
-                                (name, url, path, false, Some(e.to_string()))
-                            }
+                        match std::fs::write(&path, &buf) {
+                            Ok(()) => (name, url, path, true, None),
+                            Err(e) => (name, url, path, false, Some(e.to_string())),
                         }
                     }
-                }));
-            }
+                    Err(e) => {
+                        if path.exists()
+                            && std::fs::read(&path).is_ok_and(|buf| {
+                                serde_yml::from_slice::<serde_yml::Mapping>(&buf).is_ok()
+                            })
+                        {
+                            (name, url, path, true, None)
+                        } else {
+                            (name, url, path, false, Some(e.to_string()))
+                        }
+                    }
+                }
+            }));
         }
 
         let mut all_ok = true;
@@ -683,5 +707,178 @@ mod tests {
         );
         assert_eq!(result["inbounds"].as_array().unwrap().len(), 1);
         assert_eq!(result["log"]["level"], "info");
+    }
+
+    // ── Tests for standalone proxy-provider URL extraction during update ──────
+
+    use crate::config::database::ProxyProviderGroups;
+    use crate::functions::file::net_resource::{ExtractNetResources, ResourceSection};
+    use std::collections::BTreeMap;
+
+    /// Collect all proxy-provider download URLs from groups + generated profile,
+    /// with deduplication (same logic as in `update_template_profile`).
+    fn collect_proxy_provider_urls(
+        profile_yaml: &str,
+        groups: &ProxyProviderGroups,
+    ) -> Vec<(String, String)> {
+        let mut urls: Vec<(String, String)> = Vec::new();
+        for providers in groups.values() {
+            for (name, url) in providers {
+                urls.push((name.clone(), url.clone()));
+            }
+        }
+
+        if let Ok(mapping) = serde_yml::from_str::<serde_yml::Mapping>(profile_yaml) {
+            for resource in mapping.extract(&[ResourceSection::ProxyProvider]) {
+                let already_in_groups = groups
+                    .values()
+                    .flat_map(|providers| providers.values())
+                    .any(|url| url == &resource.url);
+                if !already_in_groups {
+                    urls.push((resource.name, resource.url));
+                }
+            }
+        }
+        urls
+    }
+
+    #[test]
+    fn standalone_proxy_provider_url_collected() {
+        let profile_yaml = r#"
+proxy-providers:
+  pvd0:
+    type: http
+    url: https://example.com/sub1.yaml
+    interval: 3600
+  bak:
+    type: http
+    url: https://hajimi.nvimy.com/file/bak.yaml
+    interval: 3600
+proxy-groups:
+  - name: "Entry"
+    type: select
+    use:
+      - pvd0
+  - name: "Special"
+    type: select
+    use:
+      - bak
+"#;
+
+        let mut providers = BTreeMap::new();
+        providers.insert("pvd0".to_string(), "https://example.com/sub1.yaml".to_string());
+        let mut groups = ProxyProviderGroups::new();
+        groups.insert("pvd".to_string(), providers);
+
+        let urls = collect_proxy_provider_urls(profile_yaml, &groups);
+
+        // Group provider (pvd0) should be included
+        assert!(urls.iter().any(|(name, _)| name == "pvd0"),
+            "pvd0 from groups should be collected");
+        // Standalone provider (bak) should also be collected
+        assert!(urls.iter().any(|(name, _)| name == "bak"),
+            "bak standalone provider should be collected");
+
+        // pvd0 should appear only once (not duplicated from extract)
+        let pvd0_count = urls.iter().filter(|(name, _)| name == "pvd0").count();
+        assert_eq!(pvd0_count, 1, "pvd0 should not be duplicated");
+    }
+
+    #[test]
+    fn standalone_proxy_provider_bak_specifically_collected() {
+        // Realistic generated profile mimicking the user's setup:
+        // two group-expanded providers (hajimi, mojie) + standalone bak
+        let profile_yaml = r#"
+proxy-providers:
+  hajimi:
+    type: http
+    url: https://hajimi.nvimy.com/file/clash.yaml
+  mojie:
+    type: http
+    url: https://hajimi.nvimy.com/file/clash_mojie.yaml
+  bak:
+    type: http
+    url: https://hajimi.nvimy.com/file/mojie_johan.yaml
+    override:
+      additional-prefix: '[bak]'
+proxy-groups:
+  - name: "Entry"
+    type: select
+    use:
+      - hajimi
+      - mojie
+  - name: "Special"
+    type: select
+    use:
+      - bak
+"#;
+
+        let mut pvd_providers = BTreeMap::new();
+        pvd_providers.insert("hajimi".to_string(), "https://hajimi.nvimy.com/file/clash.yaml".to_string());
+        pvd_providers.insert("mojie".to_string(), "https://hajimi.nvimy.com/file/clash_mojie.yaml".to_string());
+        let mut groups = ProxyProviderGroups::new();
+        groups.insert("pvd".to_string(), pvd_providers);
+
+        let urls = collect_proxy_provider_urls(profile_yaml, &groups);
+
+        assert_eq!(urls.len(), 3, "should collect 3 unique URLs: hajimi, mojie, bak");
+
+        assert!(urls.iter().any(|(name, _)| name == "hajimi"));
+        assert!(urls.iter().any(|(name, _)| name == "mojie"));
+        assert!(urls.iter().any(|(name, _)| name == "bak"),
+            "bak MUST be collected as standalone provider");
+
+        // Verify bak's URL is correct
+        let bak_url = urls.iter().find(|(name, _)| name == "bak").map(|(_, url)| url);
+        assert_eq!(bak_url, Some(&"https://hajimi.nvimy.com/file/mojie_johan.yaml".to_string()));
+    }
+
+    #[test]
+    fn empty_groups_standalone_still_collected() {
+        // When groups are empty (no tpl_param providers), standalone ones still work
+        let profile_yaml = r#"
+proxy-providers:
+  bak:
+    type: http
+    url: https://example.com/standalone.yaml
+proxy-groups:
+  - name: "Entry"
+    type: select
+    use:
+      - bak
+"#;
+        let groups = ProxyProviderGroups::new();
+
+        let urls = collect_proxy_provider_urls(profile_yaml, &groups);
+        assert_eq!(urls.len(), 1);
+        assert_eq!(urls[0].0, "bak");
+        assert!(urls[0].1.contains("standalone.yaml"));
+    }
+
+    #[test]
+    fn no_standalone_when_all_in_groups() {
+        let profile_yaml = r#"
+proxy-providers:
+  pvd0:
+    type: http
+    url: https://example.com/sub1.yaml
+  pvd1:
+    type: http
+    url: https://example.com/sub2.yaml
+proxy-groups:
+  - name: "Entry"
+    type: select
+    use:
+      - pvd0
+      - pvd1
+"#;
+        let mut providers = BTreeMap::new();
+        providers.insert("pvd0".to_string(), "https://example.com/sub1.yaml".to_string());
+        providers.insert("pvd1".to_string(), "https://example.com/sub2.yaml".to_string());
+        let mut groups = ProxyProviderGroups::new();
+        groups.insert("pvd".to_string(), providers);
+
+        let urls = collect_proxy_provider_urls(profile_yaml, &groups);
+        assert_eq!(urls.len(), 2, "only the two group providers, no duplicates");
     }
 }

--- a/src/functions/file/template/version1.rs
+++ b/src/functions/file/template/version1.rs
@@ -3,6 +3,34 @@ use anyhow::Context;
 
 use super::{PROXY_GROUPS, PROXY_PROVIDERS, resolve_template_placeholder};
 
+/// serde_yml does not support YAML `<<:` merge keys.
+/// When a mapping has a key `<<`, flatten its contents (mapping keys) into the
+/// parent mapping and remove the `<<` key.  Sequence-valued `<<` (merge of
+/// multiple mappings) is also handled — each element-mapping's keys are merged
+/// into the parent in order.
+fn flatten_yaml_merge_key(map: &mut serde_yml::Mapping) {
+    let Some(merge_val) = map.remove("<<") else {
+        return;
+    };
+    match merge_val {
+        serde_yml::Value::Mapping(inner) => {
+            for (k, v) in inner {
+                map.entry(k).or_insert(v);
+            }
+        }
+        serde_yml::Value::Sequence(seq) => {
+            for item in seq {
+                if let serde_yml::Value::Mapping(inner) = item {
+                    for (k, v) in inner {
+                        map.entry(k).or_insert(v);
+                    }
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
 struct PGitem {
     name: String,
@@ -50,7 +78,11 @@ pub(super) fn gen_template_with_urls(
 
     for (pp_key, pp_value) in pp_mapping {
         if pp_value.get("tpl_param").is_none() {
-            new_proxy_providers.insert(pp_key.clone(), pp_value.clone());
+            let mut pp_val = pp_value.clone();
+            if let Some(mapping) = pp_val.as_mapping_mut() {
+                flatten_yaml_merge_key(mapping);
+            }
+            new_proxy_providers.insert(pp_key.clone(), pp_val);
             continue;
         }
 
@@ -66,6 +98,7 @@ pub(super) fn gen_template_with_urls(
         if let Some(providers) = groups.get(pp_key_str) {
             for (name, url) in providers {
                 let mut new_pp = pp.clone();
+                flatten_yaml_merge_key(&mut new_pp);
                 new_pp.remove("tpl_param");
                 let the_pp_name = name.clone();
 
@@ -93,7 +126,11 @@ pub(super) fn gen_template_with_urls(
 
     for the_pg_value in pg_value {
         if the_pg_value.get("expand_group_with").is_none() {
-            new_proxy_groups.push(the_pg_value.clone());
+            let mut pg_val = the_pg_value.clone();
+            if let Some(mapping) = pg_val.as_mapping_mut() {
+                flatten_yaml_merge_key(mapping);
+            }
+            new_proxy_groups.push(pg_val);
             continue;
         }
 
@@ -104,6 +141,7 @@ pub(super) fn gen_template_with_urls(
         };
 
         let mut new_pg = the_pg.clone();
+        flatten_yaml_merge_key(&mut new_pg);
         new_pg.remove("expand_group_with");
 
         let provider_keys = if let Some(provider_keys) = the_pg["expand_group_with"].as_sequence() {
@@ -218,6 +256,10 @@ pub(super) fn gen_template_with_urls(
         );
         out_parsed_yaml.insert("clashtui".into(), serde_yml::Value::Mapping(clashtui_map));
     }
+
+    // Remove template-internal sections that should not appear in generated output
+    out_parsed_yaml.remove("proxy-anchor");
+    out_parsed_yaml.remove("clashtui_template_version");
 
     Ok(out_parsed_yaml)
 }
@@ -555,6 +597,234 @@ mod tests {
         // simple_tpl.yaml has ${PPG.pvd} but only "other" group exists
         let result = gen_template_with_urls(tpl, "simple_tpl", &groups);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_bak_with_anchors_and_merge_keys() {
+        // Test that YAML merge keys (<<:) are properly flattened in output
+        let yaml = r#"
+proxy-anchor:
+  - proxy_provider:
+      &pa_pp { interval: 3600, health-check: { enable: true, url: https://www.gstatic.com/generate_204, interval: 300 } }
+
+proxy-providers:
+  pvd:
+    tpl_param:
+    type: http
+    <<: *pa_pp
+  bak:
+    type: http
+    url: https://hajimi.nvimy.com/file/test.yaml
+    <<: *pa_pp
+    override:
+      additional-prefix: "[bak]"
+
+proxy-groups:
+  - name: "Entry"
+    type: select
+    proxies:
+      - DIRECT
+    use:
+      - ${PPG.pvd}
+  - name: "TestGroup"
+    type: select
+    use:
+      - bak
+"#;
+        let tpl: serde_yml::Mapping = serde_yml::from_str(yaml).unwrap();
+        let groups = make_groups("pvd", &["https://example.com/sub1.yaml"]);
+        let result = gen_template_with_urls(tpl, "test_bak_anchors", &groups).unwrap();
+
+        let providers = result
+            .get(PROXY_PROVIDERS)
+            .and_then(|v| v.as_mapping())
+            .unwrap();
+        let keys: Vec<&str> = providers.keys().filter_map(|k| k.as_str()).collect();
+        assert!(keys.contains(&"pvd0"), "Expected pvd0 in proxy-providers, got: {keys:?}");
+        assert!(keys.contains(&"bak"), "Expected bak in proxy-providers, got: {keys:?}");
+
+        // Verify << key has been flattened (interval and health-check at top level)
+        let bak = providers.get("bak").unwrap().as_mapping().unwrap();
+        assert!(bak.get("<<").is_none(), "<< key should be removed from bak");
+        assert!(bak.get("interval").is_some(), "interval should be at top level after merge flatten");
+        assert!(bak.get("health-check").is_some(), "health-check should be at top level after merge flatten");
+
+        // Verify proxy-anchor section has been stripped
+        assert!(result.get("proxy-anchor").is_none(), "proxy-anchor should be removed from output");
+
+        // Check TestGroup has bak in use
+        let groups_seq = result
+            .get(PROXY_GROUPS)
+            .and_then(|v| v.as_sequence())
+            .unwrap();
+        let test_group = groups_seq
+            .iter()
+            .find(|g| g.get("name").and_then(|n| n.as_str()) == Some("TestGroup"))
+            .expect("TestGroup should exist in proxy-groups");
+        let uses: Vec<&str> = test_group
+            .get("use")
+            .and_then(|v| v.as_sequence())
+            .unwrap()
+            .iter()
+            .filter_map(|v| v.as_str())
+            .collect();
+        assert_eq!(uses, vec!["bak"]);
+    }
+
+    #[test]
+    fn test_full_user_template() {
+        // Reproduce user's full template structure with anchors and multiple merge targets
+        let yaml = r#"
+proxy-anchor:
+  - delay_test:
+      &pa_dt { url: https://www.gstatic.com/generate_204, interval: 300 }
+  - proxy_provider:
+      &pa_pp {
+        interval: 3600,
+        health-check:
+          {
+            enable: true,
+            url: https://www.gstatic.com/generate_204,
+            interval: 300,
+          },
+      }
+  - filter:
+      &pa_flt exclude-filter: "(?i)test"
+
+proxy-providers:
+  pvd:
+    tpl_param:
+    type: http
+    <<: *pa_pp
+  bak:
+    type: http
+    url: https://hajimi.nvimy.com/file/test.yaml
+    <<: *pa_pp
+    override:
+        additional-prefix: "[bak]"
+
+proxy-groups:
+  - name: "Entry"
+    type: select
+    proxies:
+      - ${PGG.At}
+      - ${PGG.FltAt}
+    use:
+      - ${PPG.pvd}
+  - name: "At"
+    expand_group_with: ["${PPG.pvd}"]
+    type: url-test
+    <<: *pa_dt
+  - name: "FltAt"
+    expand_group_with: ["${PPG.pvd}"]
+    type: url-test
+    <<: [*pa_dt, *pa_flt]
+  - name: "SpecialGroup"
+    type: select
+    use:
+      - bak
+    <<: *pa_flt
+"#;
+        let tpl: serde_yml::Mapping = serde_yml::from_str(yaml).unwrap();
+        let groups = make_groups("pvd", &["https://example.com/sub1.yaml"]);
+        let result = gen_template_with_urls(tpl, "user_tpl", &groups).unwrap();
+
+        // Verify no << keys anywhere in proxy-providers or proxy-groups
+        let providers = result.get(PROXY_PROVIDERS).and_then(|v| v.as_mapping()).unwrap();
+        for (k, v) in providers {
+            let m = v.as_mapping().unwrap();
+            assert!(m.get("<<").is_none(), "provider {k:?} should not have << key");
+        }
+
+        let groups_seq = result.get(PROXY_GROUPS).and_then(|v| v.as_sequence()).unwrap();
+        for g in groups_seq {
+            let m = g.as_mapping().unwrap();
+            assert!(m.get("<<").is_none(), "group {:?} should not have << key", m.get("name"));
+        }
+
+        // Verify proxy-anchor is stripped
+        assert!(result.get("proxy-anchor").is_none(), "proxy-anchor should be removed");
+
+        // bak must be in proxy-providers
+        let keys: Vec<&str> = providers.keys().filter_map(|k| k.as_str()).collect();
+        assert!(keys.contains(&"bak"), "Expected bak in proxy-providers, got: {keys:?}");
+
+        // SpecialGroup must use bak
+        let special = groups_seq
+            .iter()
+            .find(|g| g.get("name").and_then(|n| n.as_str()) == Some("SpecialGroup"))
+            .expect("SpecialGroup should exist");
+        let uses: Vec<&str> = special
+            .get("use")
+            .and_then(|v| v.as_sequence())
+            .unwrap()
+            .iter()
+            .filter_map(|v| v.as_str())
+            .collect();
+        assert!(uses.contains(&"bak"), "SpecialGroup use should contain bak, got: {uses:?}");
+    }
+
+    #[test]
+    fn test_bak_proxy_provider_passthrough_with_merge_key() {
+        // Reproduce user's template with YAML merge keys (<<:) and anchors
+        let yaml = r#"
+proxy-providers:
+  pvd:
+    tpl_param:
+    type: http
+    health-check:
+      enable: true
+      url: https://www.gstatic.com/generate_204
+      interval: 300
+  bak:
+    type: http
+    url: https://hajimi.nvimy.com/file/test.yaml
+    health-check:
+      enable: true
+      url: https://www.gstatic.com/generate_204
+      interval: 300
+proxy-groups:
+  - name: "Entry"
+    type: select
+    proxies:
+      - DIRECT
+    use:
+      - ${PPG.pvd}
+  - name: "TestGroup"
+    type: select
+    use:
+      - bak
+"#;
+        let tpl: serde_yml::Mapping = serde_yml::from_str(yaml).unwrap();
+        let groups = make_groups("pvd", &["https://example.com/sub1.yaml"]);
+        let result = gen_template_with_urls(tpl, "test_bak", &groups).unwrap();
+
+        // Check proxy-providers section contains both pvd0 and bak
+        let providers = result
+            .get(PROXY_PROVIDERS)
+            .and_then(|v| v.as_mapping())
+            .unwrap();
+        let keys: Vec<&str> = providers.keys().filter_map(|k| k.as_str()).collect();
+        assert!(keys.contains(&"pvd0"), "Expected pvd0 in proxy-providers, got: {keys:?}");
+        assert!(keys.contains(&"bak"), "Expected bak in proxy-providers, got: {keys:?}");
+
+        // Check proxy-groups section contains TestGroup with bak in use list
+        let groups_seq = result
+            .get(PROXY_GROUPS)
+            .and_then(|v| v.as_sequence())
+            .unwrap();
+        let test_group = groups_seq
+            .iter()
+            .find(|g| g.get("name").and_then(|n| n.as_str()) == Some("TestGroup"))
+            .expect("TestGroup should exist in proxy-groups");
+        let uses: Vec<&str> = test_group
+            .get("use")
+            .and_then(|v| v.as_sequence())
+            .unwrap()
+            .iter()
+            .filter_map(|v| v.as_str())
+            .collect();
+        assert_eq!(uses, vec!["bak"], "TestGroup use list should contain bak");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Templates using YAML anchors and `<<:` merge keys (e.g. `<<: *pa_pp`) produced broken generated profiles because `serde_yml` 0.0.12 does not support the YAML `<<:` merge directive. Anchor values like `interval` and `health-check` were nested under a literal `<<` key instead of being at the top level where mihomo expects them.

Additionally, standalone proxy-providers (those with their own `url`, no `tpl_param`) were not being pre-downloaded during profile update. Only proxy-providers referenced in `clashtui.proxy_provider_groups` were downloaded, leaving standalone providers like `bak` out.

## Changes

### `src/functions/file/template/version1.rs`

- Added `flatten_yaml_merge_key()` — flattens `<<` merge key contents into the parent mapping and removes the `<<` key. Handles both single-mapping merges (`<<: *anchor`) and sequence-of-mappings merges (`<<: [*a, *b]`).
- Called `flatten_yaml_merge_key` at all 4 code paths that produce proxy-provider and proxy-group entries (passthrough & expanded variants).
- Stripped template-internal `proxy-anchor` and `clashtui_template_version` sections from generated output.
- Added 3 tests covering anchor/merge-key passthrough and full user-template scenarios.

### `src/functions/file/profile.rs`

- Modified `update_template_profile` to also extract and download URLs from standalone proxy-providers in the generated profile YAML.
- Uses the existing `ExtractNetResources` trait to find all proxy-provider URLs, then deduplicates against the proxy-provider groups to avoid re-downloading already-handled URLs.
- Added 5 tests covering: standalone provider collection, deduplication with group providers, empty-groups edge case, and the realistic 3-provider user scenario.

## Test Plan

```bash
cargo test --bin clashtui
# 211 passed; 0 failed
```