### PR TITLE
ci: add Windows (x86_64 + aarch64) builds to CI workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,20 @@ jobs:
             cache-suffix: macos-aarch64
             run-test: false
 
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            artifact-name: Windows_amd64_Build
+            binary-name: clashtui-windows-amd64-debug.exe
+            cache-suffix: windows-amd64
+            run-test: false
+
+          - os: windows-latest
+            target: aarch64-pc-windows-msvc
+            artifact-name: Windows_arm64_Build
+            binary-name: clashtui-windows-arm64-debug.exe
+            cache-suffix: windows-arm64
+            run-test: false
+
     steps:
       - uses: actions/checkout@v4
         with:
@@ -93,9 +107,12 @@ jobs:
           cargo build --locked --target ${{ matrix.target }}
 
       - name: Pre Upload
+        shell: bash
         run: |
-          mkdir artifacts
-          mv ./target/${{ matrix.target }}/debug/clashtui    ./artifacts/${{ matrix.binary-name }}
+          mkdir -p artifacts
+          SRC="./target/${{ matrix.target }}/debug/clashtui"
+          [ "${{ runner.os }}" = "Windows" ] && SRC="${SRC}.exe"
+          mv "$SRC" "./artifacts/${{ matrix.binary-name }}"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -49,6 +49,20 @@ jobs:
             cache-suffix: macos-aarch64
             run-test: false
 
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            artifact-name: Windows_amd64_Build
+            binary-name: clashtui-windows-amd64-debug.exe
+            cache-suffix: windows-amd64
+            run-test: false
+
+          - os: windows-latest
+            target: aarch64-pc-windows-msvc
+            artifact-name: Windows_arm64_Build
+            binary-name: clashtui-windows-arm64-debug.exe
+            cache-suffix: windows-arm64
+            run-test: false
+
     steps:
       - uses: actions/checkout@v4
 
@@ -80,9 +94,12 @@ jobs:
         run: ./target/${{ matrix.target }}/debug/clashtui --version
 
       - name: Pre Upload
+        shell: bash
         run: |
-          mkdir artifacts
-          mv ./target/${{ matrix.target }}/debug/clashtui ./artifacts/${{ matrix.binary-name }}
+          mkdir -p artifacts
+          SRC="./target/${{ matrix.target }}/debug/clashtui"
+          [ "${{ runner.os }}" = "Windows" ] && SRC="${SRC}.exe"
+          mv "$SRC" "./artifacts/${{ matrix.binary-name }}"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,22 @@ jobs:
             cache-suffix: macos-aarch64
             extract-version: false
 
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            zig-target: ''
+            artifact-name: Windows_amd64_Release
+            binary-name: clashtui-windows-amd64.exe
+            cache-suffix: windows-amd64
+            extract-version: false
+
+          - os: windows-latest
+            target: aarch64-pc-windows-msvc
+            zig-target: ''
+            artifact-name: Windows_arm64_Release
+            binary-name: clashtui-windows-arm64.exe
+            cache-suffix: windows-arm64
+            extract-version: false
+
     steps:
       - uses: actions/checkout@v4
         with:
@@ -99,9 +115,12 @@ jobs:
         run: ./target/${{ matrix.target }}/release/clashtui --version | awk '{print $2}' > version.txt
 
       - name: Pre Upload
+        shell: bash
         run: |
-          mkdir artifacts
-          mv ./target/${{ matrix.target }}/release/clashtui    ./artifacts/${{ matrix.binary-name }}
+          mkdir -p artifacts
+          SRC="./target/${{ matrix.target }}/release/clashtui"
+          [ "${{ runner.os }}" = "Windows" ] && SRC="${SRC}.exe"
+          mv "$SRC" "./artifacts/${{ matrix.binary-name }}"
           if [ -f version.txt ]; then mv version.txt ./artifacts/version.txt; fi
 
       - name: Upload artifacts
@@ -166,6 +185,8 @@ jobs:
           gzip -c ./artifacts/clashtui-arm64 > clashtui-linux-arm64-${{ env.CLASHTUI_RELEASE_VERSION }}.gz
           gzip -c ./artifacts/clashtui-darwin-amd64 > clashtui-darwin-amd64-${{ env.CLASHTUI_RELEASE_VERSION }}.gz
           gzip -c ./artifacts/clashtui-darwin-arm64 > clashtui-darwin-arm64-${{ env.CLASHTUI_RELEASE_VERSION }}.gz
+          zip -j clashtui-windows-amd64-${{ env.CLASHTUI_RELEASE_VERSION }}.zip ./artifacts/clashtui-windows-amd64.exe
+          zip -j clashtui-windows-arm64-${{ env.CLASHTUI_RELEASE_VERSION }}.zip ./artifacts/clashtui-windows-arm64.exe
 
       - name: Upload Release
         uses: softprops/action-gh-release@v2
@@ -176,3 +197,5 @@ jobs:
             clashtui-linux-arm64-${{ env.CLASHTUI_RELEASE_VERSION }}.gz
             clashtui-darwin-amd64-${{ env.CLASHTUI_RELEASE_VERSION }}.gz
             clashtui-darwin-arm64-${{ env.CLASHTUI_RELEASE_VERSION }}.gz
+            clashtui-windows-amd64-${{ env.CLASHTUI_RELEASE_VERSION }}.zip
+            clashtui-windows-arm64-${{ env.CLASHTUI_RELEASE_VERSION }}.zip


### PR DESCRIPTION
## Summary

Add Windows platform build support to GitHub Actions CI after #72 enabled Windows platform support in the codebase.

## Changes

- **`build.yml`**: Added `x86_64-pc-windows-msvc` and `aarch64-pc-windows-msvc` matrix entries running on `windows-latest`. Pre Upload step adapted to handle `.exe` extension via `runner.os` detection.
- **`pr.yml`**: Same Windows matrix additions and Pre Upload logic.
- **`release.yml`**: Same Windows matrix additions. Release artifacts for Windows are packaged as `.zip` (instead of `.gz`) for native Windows consumption. Updated both the Archive Release and Upload Release steps accordingly.

## Artifacts

| Platform | Arch | Binary | Release Package |
|----------|------|--------|-----------------|
| Windows  | x86_64 | `clashtui-windows-amd64.exe` | `clashtui-windows-amd64-vX.Y.Z.zip` |
| Windows  | aarch64 | `clashtui-windows-arm64.exe` | `clashtui-windows-arm64-vX.Y.Z.zip` |

## Related

- #72 (Windows platform support)