### PR TITLE
feat: add Update GEO in Settings; clean up default shortcut hints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1734,9 +1734,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2683,12 +2683,12 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winreg"
-version = "0.55.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
+checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
 dependencies = [
  "cfg-if",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,9 +84,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "base64"
@@ -135,9 +135,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
@@ -476,9 +476,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "env_filter"
@@ -717,9 +717,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",
@@ -903,9 +903,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.24"
+version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
+checksum = "30457d51cb0e68ee18184b30cd9eb8e1602a20837c321f6ea9706b94f1c681c3"
 dependencies = [
  "jiff-static",
  "log",
@@ -916,9 +916,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.24"
+version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
+checksum = "05f86e4f0326c61ae6c00b04d9009aaeda644d0b5bdfbf6c67247f492f42b3f3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -927,9 +927,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2294,9 +2294,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2307,9 +2307,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2317,9 +2317,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2330,9 +2330,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1225,7 +1225,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2475,47 +2475,46 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.61.3"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
  "windows-collections",
  "windows-core",
  "windows-future",
- "windows-link 0.1.3",
  "windows-numerics",
 ]
 
 [[package]]
 name = "windows-collections"
-version = "0.2.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
  "windows-core",
 ]
 
 [[package]]
 name = "windows-core"
-version = "0.61.2"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link 0.1.3",
+ "windows-link",
  "windows-result",
  "windows-strings",
 ]
 
 [[package]]
 name = "windows-future"
-version = "0.2.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
  "windows-core",
- "windows-link 0.1.3",
+ "windows-link",
  "windows-threading",
 ]
 
@@ -2543,42 +2542,36 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-numerics"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
  "windows-core",
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-result"
-version = "0.3.4"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.4.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -2605,7 +2598,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2626,11 +2619,11 @@ dependencies = [
 
 [[package]]
 name = "windows-threading"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1026,9 +1026,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "lru"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ pre-release-commands = ["cargo test"]
 publish = true
 
 [dependencies]
-log = "0.4.22"
+log = "0.4.30"
 env_logger = { version = "0.11.7", default-features = false, features = [
     "humantime",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ env_logger = { version = "0.11.7", default-features = false, features = [
 ] }
 anyhow = "1.0.86"
 serde = { version = "1.0.210", features = ["derive"] }
-serde_json = "1.0.128"
+serde_json = "1.0.150"
 serde_yml = "0.0.12"
 indexmap = { version = "2", features = ["serde"] }
 minreq = { version = "2.12.0", features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ libc = "0.2"
 signal-hook-tokio = { version = "0", features = ["futures-v0_3"], optional = true }
 
 [target.'cfg(windows)'.dependencies]
-winreg = "0.55"
+winreg = "0.56"
 windows = { version = "0.61", features = [
     "Win32_UI_WindowsAndMessaging",
     "Win32_Foundation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ signal-hook-tokio = { version = "0", features = ["futures-v0_3"], optional = tru
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.55"
-windows = { version = "0.61", features = [
+windows = { version = "0.62", features = [
     "Win32_UI_WindowsAndMessaging",
     "Win32_Foundation",
     "Win32_Security",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ signal-hook-tokio = { version = "0", features = ["futures-v0_3"], optional = tru
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.56"
-windows = { version = "0.61", features = [
+windows = { version = "0.62", features = [
     "Win32_UI_WindowsAndMessaging",
     "Win32_Foundation",
     "Win32_Security",

--- a/src/functions/restful.rs
+++ b/src/functions/restful.rs
@@ -71,6 +71,17 @@ pub mod cache {
     }
 }
 
+pub mod geo {
+    use super::*;
+
+    /// Update GEO databases
+    ///
+    /// API: POST /configs/geo
+    pub fn upgrade_geo() -> Result<()> {
+        request(Method::Post, "/configs/geo", None).map(|_| ())
+    }
+}
+
 pub mod config {
     use super::*;
 

--- a/src/tui/tab/connections.rs
+++ b/src/tui/tab/connections.rs
@@ -852,12 +852,16 @@ mod tests {
         let mut title = if let Some(filter) = self.filter.as_ref() {
             format!(" / {filter} ")
         } else {
-            " /: Search ".to_owned()
+            String::new()
         };
         if self.paused {
             title.push_str(" [PAUSED]");
         }
-        let block = block.title_bottom(Line::raw(title).right_aligned().reversed());
+        let block = if title.is_empty() {
+            block
+        } else {
+            block.title_bottom(Line::raw(title).right_aligned().reversed())
+        };
 
         if !self.error.as_deref().unwrap_or("").is_empty() && self.display_rows.is_empty() {
             let widget =

--- a/src/tui/tab/files/profile.rs
+++ b/src/tui/tab/files/profile.rs
@@ -442,7 +442,7 @@ impl DualTabContent for Profile {
         let block = if let Some(filter) = self.filter.as_ref() {
             block.title_bottom(Line::raw(format!(" {filter} ")).right_aligned().reversed())
         } else {
-            block.title_bottom(Line::raw(format!(" /: Search ")).right_aligned().reversed())
+            block
         };
 
         let current = &crate::config::CONFIG

--- a/src/tui/tab/files/template.rs
+++ b/src/tui/tab/files/template.rs
@@ -293,7 +293,7 @@ impl DualTabContentMate for Template {
         let block = if let Some(filter) = self.filter.as_ref() {
             block.title_bottom(Line::raw(format!(" {filter} ")).right_aligned().reversed())
         } else {
-            block.title_bottom(Line::raw(format!(" /: Search ")).right_aligned().reversed())
+            block
         };
 
         let iter = self

--- a/src/tui/tab/logs.rs
+++ b/src/tui/tab/logs.rs
@@ -439,13 +439,15 @@ impl TabContent for Logs {
         title_parts.push(self.current_log_level.clone());
         if let Some(ref filter) = self.filter {
             title_parts.push(format!(" / {filter} "));
-        } else {
-            title_parts.push(" /: Search ".to_owned());
         }
         if self.paused {
             title_parts.push(" [PAUSED]".to_owned());
         }
-        let block = block.title_bottom(Line::raw(title_parts.join(" ")).right_aligned().reversed());
+        let block = if title_parts.len() > 1 {
+            block.title_bottom(Line::raw(title_parts.join(" ")).right_aligned().reversed())
+        } else {
+            block
+        };
 
         if !self.error.as_deref().unwrap_or("").is_empty() && self.buffer.is_empty() {
             let widget =

--- a/src/tui/tab/proxies/render.rs
+++ b/src/tui/tab/proxies/render.rs
@@ -100,8 +100,6 @@ pub fn render(content: &Proxies, f: &mut Frame, area: Rect, state: &mut ListStat
     // Filter indicator
     if let Some(ref f) = content.filter {
         footer_parts.push(format!("/ {f} "));
-    } else {
-        footer_parts.push("/: Filter ".to_owned());
     }
 
     let footer = footer_parts.join("");

--- a/src/tui/tab/settings.rs
+++ b/src/tui/tab/settings.rs
@@ -58,6 +58,7 @@ enum SettingsOp {
     TunStackOp,
     FlushFakeIP,
     FlushDNSCache,
+    UpdateGeo,
 }
 
 impl SettingsOp {
@@ -68,6 +69,7 @@ impl SettingsOp {
             ops.push(Self::TunStackOp);
             ops.push(Self::FlushFakeIP);
             ops.push(Self::FlushDNSCache);
+            ops.push(Self::UpdateGeo);
         }
         ops
     }
@@ -380,6 +382,26 @@ impl TabContent for SettingsContent {
                         }
                         .spawn_at(task_set);
                     }
+                    SettingsOp::UpdateGeo => {
+                        async move {
+                            if crate::config::is_core_mismatch() {
+                                return do_nothing();
+                            }
+                            let result = tokio::task::spawn_blocking(|| {
+                                crate::functions::restful::geo::upgrade_geo()
+                            })
+                            .await
+                            .unwrap();
+                            match result {
+                                Ok(_) => do_nothing(),
+                                Err(e) => {
+                                    crate::tui::widget::popmsg::Confirm::err(e);
+                                    do_nothing()
+                                }
+                            }
+                        }
+                        .spawn_at(task_set);
+                    }
                 }
             }
             _ => {}
@@ -416,6 +438,7 @@ impl TabContent for SettingsContent {
                     SettingsOp::TunStackOp => ("TUN Stack", self.tun_stack.as_str()),
                     SettingsOp::FlushFakeIP => ("Flush Fake-IP", ""),
                     SettingsOp::FlushDNSCache => ("Flush DNS Cache", ""),
+                    SettingsOp::UpdateGeo => ("Update GEO", ""),
                 };
                 ListItem::new(Line::from(vec![
                     Span::raw(format!("  {:<14}", name)),


### PR DESCRIPTION
## Summary

Two changes in this PR:

### 1. Add "Update GEO" option in Settings panel

Adds a new "Update GEO" menu item in the Settings tab (tab 6) that triggers a `POST /configs/geo` API call to update the GEO databases (GeoIP, GeoSite) on the connected mihomo backend.

- **src/functions/restful.rs**: Added `geo::upgrade_geo()` function calling `POST /configs/geo`
- **src/tui/tab/settings.rs**: Added `UpdateGeo` variant to `SettingsOp` enum (mihomo-only, consistent with other core-specific actions)

Refs: https://wiki.metacubex.one/en/api/#upgradegeo

### 2. Remove default shortcut hints from tab footers

The default placeholder text (e.g. `/: Search`, `/: Filter`) in the bottom-right corner of tabs has been removed. Tabs now only display the shortcut hint when a filter/search is active.

- **src/tui/tab/connections.rs**: Only show filter text in footer when a filter is set
- **src/tui/tab/logs.rs**: Only show filter text when a filter is set
- **src/tui/tab/proxies/render.rs**: Only show filter text when a filter is set
- **src/tui/tab/files/profile.rs**: Only show search hint when a filter is active
- **src/tui/tab/files/template.rs**: Only show search hint when a filter is active

## Files Changed

| File | Changes |
|------|---------|
| `src/functions/restful.rs` | +11 |
| `src/tui/tab/settings.rs` | +23 |
| `src/tui/tab/connections.rs` | +6/-2 |
| `src/tui/tab/logs.rs` | +5/-3 |
| `src/tui/tab/proxies/render.rs` | +0/-2 |
| `src/tui/tab/files/profile.rs` | +1/-1 |
| `src/tui/tab/files/template.rs` | +1/-1 |
| **Total** | **+47/-9** |