### PR TITLE
feat: OpenRC service controller support + manual install docs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,23 +76,18 @@ jobs:
       - uses: goto-bus-stop/setup-zig@v2
         if: matrix.zig-target
 
-      - name: Cache Target
+      - name: Cache Cargo registry
         uses: actions/cache@v4
         with:
-          path: |
-            ./target
-            ~/.cargo
+          path: ~/.cargo
           key: ci-${{ matrix.cache-suffix }}-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            ci-${{ matrix.cache-suffix }}-${{ hashFiles('Cargo.lock') }}
-            ci-${{ matrix.cache-suffix }}-
 
       - name: Download Dependencies
         run: cargo fetch
 
       - name: Run tests
         if: matrix.run-test
-        run: cargo test --all --all-features
+        run: cargo test --locked --all --all-features
 
       - name: Build (zig + glibc 2.17)
         if: matrix.zig-target

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -67,23 +67,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Cache Target
+      - name: Cache Cargo registry
         uses: actions/cache@v4
         with:
-          path: |
-            ./target
-            ~/.cargo
-          key: ci-pr-${{ matrix.cache-suffix }}-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            ci-pr-${{ matrix.cache-suffix }}-${{ hashFiles('Cargo.lock') }}
-            ci-pr-${{ matrix.cache-suffix }}-
+          path: ~/.cargo
+          key: ci-${{ matrix.cache-suffix }}-${{ hashFiles('Cargo.lock') }}
 
       - name: Download Dependencies
         run: cargo fetch
 
       - name: Run tests
         if: matrix.run-test
-        run: cargo test --all --all-features --verbose
+        run: cargo test --locked --all --all-features --verbose
 
       - name: Build
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,15 +84,11 @@ jobs:
       - uses: goto-bus-stop/setup-zig@v2
         if: matrix.zig-target
 
-      - name: Cache Target
+      - name: Cache Cargo registry
         uses: actions/cache@v4
         with:
-          path: |
-            ~/.cargo
-            ./target
-          key: ci-release-${{ matrix.cache-suffix }}-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            ci-release-${{ matrix.cache-suffix }}-
+          path: ~/.cargo
+          key: ci-${{ matrix.cache-suffix }}-${{ hashFiles('Cargo.lock') }}
 
       - name: Download Dependencies
         run: cargo fetch

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ launchctl load -w ~/Library/LaunchAgents/clashtui_singbox.plist
 | Document | Description |
 |----------|-------------|
 | [Getting Started](docs/getting_started_en.md) | Detailed usage guide: UI operations, CLI, subscription management, config reference, FAQ |
+| [Manual Installation](docs/install_manually_en.md) | Step-by-step manual installation for system/user mode |
 | [Feature Design](docs/ClashTui_feature_design_en.md) | Feature design: config structure, subscription management, Template expansion, sing-box merge algorithm |
 | [Architecture](docs/architecture_en.md) | Code architecture: module structure, startup flow, TUI event loop, Tab system |
 | [Development Conventions](docs/development_conventions.md) | Branch naming, commit format, CHANGELOG conventions |

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -159,6 +159,7 @@ launchctl load -w ~/Library/LaunchAgents/clashtui_singbox.plist
 | 文档 | 说明 |
 |------|------|
 | [使用指南](docs/getting_started_zh.md) | 详细使用教程：界面操作、命令行、订阅管理、配置说明、常见问题 |
+| [手动安装](docs/install_manually_zh.md) | system/user 模式手动安装步骤 |
 | [功能设计](docs/ClashTui_feature_design_zh.md) | 功能设计文档：配置结构、订阅管理、Template 展开、sing-box 合并算法 |
 | [架构](docs/architecture_zh.md) | 代码架构文档：模块结构、启动流程、TUI 事件循环、Tab 体系 |
 | [开发约定](docs/development_conventions.md) | 分支命名、提交规范、CHANGELOG 约定 |
@@ -168,5 +169,5 @@ launchctl load -w ~/Library/LaunchAgents/clashtui_singbox.plist
 欢迎提交 Issue 和 Pull Request。参与开发前请先阅读[开发约定](docs/development_conventions.md)。
 
 快速了解项目, 加入开发:
-1.  docs/ClashTui_feature_design_zh.md
-2.  docs/architecture_zh.md
+1. [功能设计](docs/ClashTui_feature_design_zh.md) — 了解功能设计
+2. [架构](docs/architecture_zh.md) — 了解代码结构

--- a/docs/clashtui_feature_design_en.md
+++ b/docs/clashtui_feature_design_en.md
@@ -1240,3 +1240,101 @@ D:\clashtui\
 #### Service Registration
 
 The script registers Windows Services via clashtui's own `clashtui service install` subcommand, which uses the `windows-service` crate to call the SCM API — no external tools required.
+
+## Linux Platform Support for `openrc` Service Controller
+
+### Overview
+
+ClashTui defaults to `systemd` as the service manager on Linux. Support for `openrc` is added for Linux distributions running OpenRC (e.g. Gentoo, Alpine).
+
+### Configuration Field
+
+The `service_controller` field is added to `core_service` sections in `config.yaml`:
+
+```yaml
+core_service:
+  service_name: clashtui_mihomo
+  is_user: false
+  service_controller: openrc   # Optional: systemd (default) / openrc
+```
+
+- `"systemd"` or absent → uses systemd
+- `"openrc"` → uses OpenRC (`rc-service`/`rc-update`)
+- Non-Linux platforms ignore this field, using platform default
+
+### Runtime Behavior
+
+| Operation    | systemd Command                    | OpenRC Command                    |
+|-------------|------------------------------------|----------------------------------|
+| Start        | `systemctl start <name>`           | `rc-service <name> start`        |
+| Stop         | `systemctl stop <name>`            | `rc-service <name> stop`         |
+| Restart      | `systemctl restart <name>`         | `rc-service <name> restart`      |
+| Reload       | `systemctl reload <name>`          | `rc-service <name> restart`      |
+| Status       | `systemctl is-active <name>`       | `rc-service <name> status`       |
+
+`is_user` determines sudo/--user prefix:
+
+- `is_user: false`: `sudo rc-service <name> <op>` (system mode)
+- `is_user: true`: `rc-service --user <name> <op>` (user mode)
+- OpenRC has supported user services since v0.60; scripts go in `/etc/user/init.d/`; requires `XDG_RUNTIME_DIR` to be set
+
+### Install Script (`installs/install`)
+
+The `install` script accepts a `--service-controller` argument:
+
+```bash
+# Default: systemd
+./install --core all
+
+# OpenRC (system mode)
+./install --service-controller openrc --core all
+
+# OpenRC (user mode)
+./install --service-controller openrc --is-user --core all
+```
+
+When `--service-controller openrc`:
+- System mode: generates OpenRC init scripts in `/etc/init.d/`, uses `command_user` for the service user
+- User mode: generates OpenRC init scripts in `/etc/user/init.d/` (requires sudo to write), no `command_user` (runs as current user)
+- `config.yaml` is written with `service_controller: openrc` and the corresponding `is_user` value
+- Uses `supervise-daemon` to manage foreground processes
+
+Generated OpenRC init script — system mode (mihomo):
+
+```sh
+#!/sbin/openrc-run
+
+supervisor="supervise-daemon"
+name="clashtui_mihomo"
+description="mihomo Daemon, Another Clash Kernel."
+command="/opt/clashtui/mihomo/mihomo"
+command_args="-d /opt/clashtui/mihomo/config"
+command_user="mihomo:mihomo"
+pidfile="/run/${RC_SVCNAME}.pid"
+
+depend() {
+    need net
+}
+```
+
+Generated OpenRC init script — user mode (mihomo):
+
+```sh
+#!/sbin/openrc-run
+
+supervisor="supervise-daemon"
+name="clashtui_mihomo"
+description="mihomo Daemon, Another Clash Kernel."
+command="/home/<user>/.local/clashtui/mihomo/mihomo"
+command_args="-d /home/<user>/.local/clashtui/mihomo/config"
+
+depend() {
+    need net
+}
+```
+
+### Uninstall (`--uninstall`)
+
+`install --uninstall` correctly handles openrc mode:
+- System mode: runs `sudo rc-update del`, `sudo rc-service stop`, removes scripts from `/etc/init.d/`
+- User mode: runs `rc-update --user del`, `rc-service --user stop`, removes scripts from `/etc/user/init.d/`

--- a/docs/clashtui_feature_design_zh.md
+++ b/docs/clashtui_feature_design_zh.md
@@ -1128,3 +1128,102 @@ CoreSrvCtl tab 的操作列表:
 ### Windows 文件路径的格式
 
 统一使用 `D:/Foo/Bar` 的格式, 而不使用 `D:\\Foo\\Bar` 的形式 (觉得不好看, 和不方便处理)。
+
+## Linux 平台支持 `openrc` service controller
+
+### 概述
+
+ClashTui 在 Linux 平台上默认使用 `systemd` 作为服务管理器。为了支持运行 OpenRC 的 Linux 发行版 (如 Gentoo, Alpine), 需要支持 `openrc` service controller。
+
+### 配置字段
+
+在 `config.yaml` 的 `core_service` 段中, 新增 `service_controller` 字段:
+
+```yaml
+core_service:
+  service_name: clashtui_mihomo
+  is_user: false
+  service_controller: openrc   # 可选: systemd (默认) / openrc
+```
+
+- 当值为 `"systemd"` 或不填时, 使用 systemd
+- 当值为 `"openrc"` 时, 使用 OpenRC (`rc-service`/`rc-update`)
+- 非 Linux 平台忽略此字段, 使用平台默认值
+
+### 运行时行为
+
+| 操作         | systemd 命令                          | OpenRC 命令                        |
+|-------------|---------------------------------------|------------------------------------|
+| 启动服务      | `systemctl start <name>`              | `rc-service <name> start`          |
+| 停止服务      | `systemctl stop <name>`               | `rc-service <name> stop`           |
+| 重启服务      | `systemctl restart <name>`            | `rc-service <name> restart`        |
+| 重载         | `systemctl reload <name>`             | `rc-service <name> restart`        |
+| 查询状态      | `systemctl is-active <name>`          | `rc-service <name> status`         |
+
+通过 config 内的 `is_user` 参数判断是否使用 `--user` 或 `sudo` 前缀:
+
+- `is_user: false`: 使用 `sudo rc-service <name> <op>` (system 模式)
+- `is_user: true`: 使用 `rc-service --user <name> <op>` (user 模式)
+- OpenRC 从 v0.60 起支持 user service, 脚本放在 `/etc/user/init.d/`, 需要 `XDG_RUNTIME_DIR` 已设置
+
+### install 脚本 (installs/install)
+
+`install` 脚本新增 `--service-controller` 参数:
+
+```bash
+# 默认 systemd
+./install --core all
+
+# 使用 OpenRC (system 模式)
+./install --service-controller openrc --core all
+
+# 使用 OpenRC (user 模式)
+./install --service-controller openrc --is-user --core all
+```
+
+当 `--service-controller openrc` 时:
+- System 模式: 在 `/etc/init.d/` 下生成 OpenRC init 脚本, 使用 `command_user` 指定运行用户
+- User 模式: 在 `/etc/user/init.d/` 下生成 OpenRC init 脚本 (需要 sudo 写入), 不使用 `command_user` (以当前用户运行)
+- config.yaml 中写入 `service_controller: openrc` 和相应的 `is_user` 值
+- init 脚本使用 `supervise-daemon` 管理前台进程
+
+生成的 OpenRC init 脚本示例 — system 模式 (mihomo):
+
+```sh
+#!/sbin/openrc-run
+
+supervisor="supervise-daemon"
+name="clashtui_mihomo"
+description="mihomo Daemon, Another Clash Kernel."
+command="/opt/clashtui/mihomo/mihomo"
+command_args="-d /opt/clashtui/mihomo/config"
+command_user="mihomo:mihomo"
+pidfile="/run/${RC_SVCNAME}.pid"
+
+depend() {
+    need net
+}
+```
+
+生成的 OpenRC init 脚本示例 — user 模式 (mihomo):
+
+```sh
+#!/sbin/openrc-run
+
+supervisor="supervise-daemon"
+name="clashtui_mihomo"
+description="mihomo Daemon, Another Clash Kernel."
+command="/home/<user>/.local/clashtui/mihomo/mihomo"
+command_args="-d /home/<user>/.local/clashtui/mihomo/config"
+
+depend() {
+    need net
+}
+```
+
+### 卸载 (--uninstall)
+
+`install --uninstall` 能正确识别 openrc 模式:
+- System 模式: 执行 `sudo rc-update del` 和 `sudo rc-service stop`, 删除 `/etc/init.d/` 下的脚本
+- User 模式: 执行 `rc-update --user del` 和 `rc-service --user stop`, 删除 `/etc/user/init.d/` 下的脚本
+

--- a/docs/install_manually_en.md
+++ b/docs/install_manually_en.md
@@ -1,0 +1,515 @@
+# ClashTui Manual Installation Guide
+
+Using Arch Linux, amd64, systemd as an example. Steps for both system mode and user mode are provided below.
+
+---
+
+# System Mode
+
+## Directory Layout
+
+After installation:
+
+```
+/opt/clashtui/
+├── bin/
+│   └── clashtui
+├── mihomo/
+│   ├── mihomo
+│   └── config/
+│       └── config.yaml
+└── sing-box/
+    ├── sing-box
+    └── config/
+        └── config.json
+
+~/.config/clashtui/
+├── config.yaml
+├── default_keymap.yaml
+├── default_theme.yaml
+├── mihomo/
+│   ├── core_override_config.yaml
+│   ├── template_proxy_providers.yaml
+│   ├── profiles/
+│   └── templates/
+└── sing-box/
+    ├── core_override_config.json
+    ├── template_proxy_providers.yaml
+    ├── profiles/
+    └── templates/
+```
+
+## 1. Download ClashTui
+
+```sh
+curl -LO "https://github.com/JohanChane/clashtui/releases/latest/download/clashtui-linux-amd64-$(curl -s https://api.github.com/repos/JohanChane/clashtui/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/').gz"
+gunzip clashtui-linux-amd64-*.gz
+chmod +x clashtui-linux-amd64-*
+sudo mkdir -p /opt/clashtui/bin
+sudo install -m 755 clashtui-linux-amd64-* /opt/clashtui/bin/clashtui
+sudo ln -sf /opt/clashtui/bin/clashtui /usr/local/bin/clashtui
+```
+
+## 2. Download Mihomo
+
+```sh
+mihomo_ver=$(curl -s https://api.github.com/repos/MetaCubeX/mihomo/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+curl -L "https://github.com/MetaCubeX/mihomo/releases/latest/download/mihomo-linux-amd64-${mihomo_ver}.gz" -o /tmp/mihomo.gz
+gunzip -c /tmp/mihomo.gz > /tmp/mihomo
+sudo mkdir -p /opt/clashtui/mihomo
+sudo install -m 755 /tmp/mihomo /opt/clashtui/mihomo/mihomo
+```
+
+## 3. Download sing-box
+
+```sh
+sb_ver=$(curl -s https://api.github.com/repos/SagerNet/sing-box/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+curl -L "https://github.com/SagerNet/sing-box/releases/latest/download/sing-box-${sb_ver}-linux-amd64.tar.gz" -o /tmp/sing-box.tar.gz
+tar -xzf /tmp/sing-box.tar.gz -C /tmp/
+sudo mkdir -p /opt/clashtui/sing-box
+sudo install -m 755 /tmp/sing-box-*/sing-box /opt/clashtui/sing-box/sing-box
+sudo ln -sf /opt/clashtui/sing-box/sing-box /usr/bin/sing-box
+```
+
+## 4. Create ClashTui Main Config
+
+```sh
+mkdir -p ~/.config/clashtui
+```
+
+`~/.config/clashtui/config.yaml`:
+
+```yaml
+mihomo:
+  core:
+    config_dir: /opt/clashtui/mihomo/config
+    bin_path: /opt/clashtui/mihomo/mihomo
+    config_path: /opt/clashtui/mihomo/config/config.yaml
+  core_service:
+    service_name: clashtui_mihomo
+    is_user: false
+    service_controller: systemd
+singbox:
+  core:
+    bin_path: /opt/clashtui/sing-box/sing-box
+    config_dir: /opt/clashtui/sing-box/config
+    config_path: /opt/clashtui/sing-box/config/config.json
+  core_service:
+    service_name: clashtui_singbox
+    is_user: false
+    service_controller: systemd
+timeout: null
+extra:
+  edit_cmd:
+  open_dir_cmd:
+```
+
+## 5. Create Core Configs
+
+```sh
+sudo mkdir -p /opt/clashtui/mihomo/config
+sudo mkdir -p /opt/clashtui/sing-box/config
+mkdir -p ~/.config/clashtui/mihomo
+mkdir -p ~/.config/clashtui/sing-box
+```
+
+Download core override configs from GitHub:
+
+```sh
+base="https://raw.githubusercontent.com/JohanChane/clashtui/main/contrib/default_configs"
+
+# Mihomo
+curl -o ~/.config/clashtui/mihomo/core_override_config.yaml \
+  "${base}/mihomo/core_override_config.yaml"
+sudo cp ~/.config/clashtui/mihomo/core_override_config.yaml \
+  /opt/clashtui/mihomo/config/config.yaml
+
+# sing-box
+curl -o ~/.config/clashtui/sing-box/core_override_config.json \
+  "${base}/sing-box/core_override_config.json"
+sudo cp ~/.config/clashtui/sing-box/core_override_config.json \
+  /opt/clashtui/sing-box/config/config.json
+```
+
+## 6. Download Default Files
+
+```sh
+curl -o ~/.config/clashtui/default_keymap.yaml \
+  "${base}/default_keymap.yaml"
+curl -o ~/.config/clashtui/default_theme.yaml \
+  "${base}/default_theme.yaml"
+```
+
+## 7. Create Users and Permissions
+
+```sh
+sudo groupadd --system mihomo
+sudo useradd --system --no-create-home --gid mihomo --shell /bin/false mihomo
+sudo groupadd --system sing-box
+sudo useradd --system --no-create-home --gid sing-box --shell /bin/false sing-box
+
+sudo gpasswd -a $USER mihomo
+sudo gpasswd -a $USER sing-box
+
+# After adding your user to the groups, re-login is required for the changes to take effect
+
+sudo chown -R mihomo:mihomo /opt/clashtui/mihomo
+sudo chmod g+rwxs /opt/clashtui/mihomo/config
+sudo chown -R sing-box:sing-box /opt/clashtui/sing-box
+sudo chmod g+rwxs /opt/clashtui/sing-box/config
+```
+
+## 8. Create systemd Services
+
+**clashtui_mihomo** — write to `/opt/clashtui/mihomo/clashtui_mihomo.service`:
+
+```ini
+[Unit]
+Description=mihomo Daemon, Another Clash Kernel.
+After=network.target NetworkManager.service systemd-networkd.service iwd.service
+
+[Service]
+Type=simple
+User=mihomo
+Group=mihomo
+LimitNPROC=500
+LimitNOFILE=1000000
+CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_RAW CAP_NET_BIND_SERVICE CAP_SYS_TIME CAP_SYS_PTRACE CAP_DAC_READ_SEARCH CAP_DAC_OVERRIDE
+AmbientCapabilities=CAP_NET_ADMIN CAP_NET_RAW CAP_NET_BIND_SERVICE CAP_SYS_TIME CAP_SYS_PTRACE CAP_DAC_READ_SEARCH CAP_DAC_OVERRIDE
+Restart=always
+ExecStartPre=/usr/bin/sleep 1s
+ExecStart=/opt/clashtui/mihomo/mihomo -d /opt/clashtui/mihomo/config
+ExecReload=/bin/kill -HUP $MAINPID
+
+[Install]
+WantedBy=multi-user.target
+```
+
+**clashtui_singbox** — write to `/opt/clashtui/sing-box/clashtui_singbox.service`:
+
+```ini
+[Unit]
+Description=sing-box Daemon, The universal proxy platform.
+After=network.target NetworkManager.service systemd-networkd.service iwd.service
+
+[Service]
+Type=simple
+User=sing-box
+Group=sing-box
+StateDirectory=sing-box
+CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_RAW CAP_NET_BIND_SERVICE CAP_SYS_PTRACE CAP_DAC_READ_SEARCH
+AmbientCapabilities=CAP_NET_ADMIN CAP_NET_RAW CAP_NET_BIND_SERVICE CAP_SYS_PTRACE CAP_DAC_READ_SEARCH
+ExecStartPre=/usr/bin/sleep 1s
+ExecStart=/usr/bin/sing-box -D /opt/clashtui/sing-box/config -c /opt/clashtui/sing-box/config/config.json run
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=on-failure
+RestartSec=10s
+LimitNOFILE=infinity
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Enable services:
+
+```sh
+sudo ln -sf /opt/clashtui/mihomo/clashtui_mihomo.service /usr/lib/systemd/system/
+sudo ln -sf /opt/clashtui/sing-box/clashtui_singbox.service /usr/lib/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable clashtui_mihomo
+sudo systemctl enable clashtui_singbox
+```
+
+## 9. Create Subscription Configs
+
+`~/.config/clashtui/mihomo/template_proxy_providers.yaml`:
+
+```yaml
+# Define proxy-provider subscription URLs here
+# pvd:
+#   pvd0: "https://example.com/sub.yaml"
+```
+
+Same for `~/.config/clashtui/sing-box/template_proxy_providers.yaml`.
+
+Create required directories:
+
+```sh
+mkdir -p ~/.config/clashtui/mihomo/{profiles,templates}
+mkdir -p ~/.config/clashtui/sing-box/{profiles,templates}
+```
+
+## 10. Download Rule Files (Optional)
+
+```sh
+curl -Lo /opt/clashtui/mihomo/config/geoip.metadb \
+  https://github.com/MetaCubeX/meta-rules-dat/releases/latest/download/geoip.metadb
+curl -Lo /opt/clashtui/mihomo/config/GeoSite.dat \
+  https://github.com/MetaCubeX/meta-rules-dat/releases/latest/download/geosite.dat
+```
+
+## 11. Launch
+
+```sh
+clashtui
+```
+
+## Uninstall
+
+```sh
+sudo systemctl stop clashtui_mihomo clashtui_singbox
+sudo rm -f /usr/lib/systemd/system/clashtui_mihomo.service
+sudo rm -f /usr/lib/systemd/system/clashtui_singbox.service
+sudo systemctl daemon-reload
+sudo rm -rf /opt/clashtui
+rm -rf ~/.config/clashtui
+rm -rf ~/.cache/clashtui
+sudo userdel mihomo
+sudo userdel sing-box
+```
+
+---
+
+# User Mode
+
+Install to `~/.local/clashtui/` without root privileges. Services run as the current user.
+
+## Directory Layout
+
+```
+~/.local/clashtui/
+├── bin/
+│   └── clashtui
+├── mihomo/
+│   ├── mihomo
+│   └── config/
+│       └── config.yaml
+└── sing-box/
+    ├── sing-box
+    └── config/
+        └── config.json
+
+~/.config/clashtui/
+├── config.yaml
+├── default_keymap.yaml
+├── default_theme.yaml
+├── mihomo/
+│   ├── core_override_config.yaml
+│   ├── template_proxy_providers.yaml
+│   ├── profiles/
+│   └── templates/
+└── sing-box/
+    ├── core_override_config.json
+    ├── template_proxy_providers.yaml
+    ├── profiles/
+    └── templates/
+```
+
+## 1. Download ClashTui
+
+```sh
+curl -LO "https://github.com/JohanChane/clashtui/releases/latest/download/clashtui-linux-amd64-$(curl -s https://api.github.com/repos/JohanChane/clashtui/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/').gz"
+gunzip clashtui-linux-amd64-*.gz
+chmod +x clashtui-linux-amd64-*
+mkdir -p ~/.local/clashtui/bin
+install -m 755 clashtui-linux-amd64-* ~/.local/clashtui/bin/clashtui
+ln -sf ~/.local/clashtui/bin/clashtui ~/.local/bin/clashtui
+```
+
+## 2. Download Mihomo
+
+```sh
+mihomo_ver=$(curl -s https://api.github.com/repos/MetaCubeX/mihomo/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+curl -L "https://github.com/MetaCubeX/mihomo/releases/latest/download/mihomo-linux-amd64-${mihomo_ver}.gz" -o /tmp/mihomo.gz
+gunzip -c /tmp/mihomo.gz > /tmp/mihomo
+mkdir -p ~/.local/clashtui/mihomo
+install -m 755 /tmp/mihomo ~/.local/clashtui/mihomo/mihomo
+```
+
+## 3. Download sing-box
+
+```sh
+sb_ver=$(curl -s https://api.github.com/repos/SagerNet/sing-box/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+curl -L "https://github.com/SagerNet/sing-box/releases/latest/download/sing-box-${sb_ver}-linux-amd64.tar.gz" -o /tmp/sing-box.tar.gz
+tar -xzf /tmp/sing-box.tar.gz -C /tmp/
+mkdir -p ~/.local/clashtui/sing-box
+install -m 755 /tmp/sing-box-*/sing-box ~/.local/clashtui/sing-box/sing-box
+ln -sf ~/.local/clashtui/sing-box/sing-box ~/.local/bin/sing-box
+```
+
+## 4. Create ClashTui Main Config
+
+```sh
+mkdir -p ~/.config/clashtui
+```
+
+`~/.config/clashtui/config.yaml`:
+
+```yaml
+mihomo:
+  core:
+    config_dir: <HOME_REPLACE>/.local/clashtui/mihomo/config
+    bin_path: <HOME_REPLACE>/.local/clashtui/mihomo/mihomo
+    config_path: <HOME_REPLACE>/.local/clashtui/mihomo/config/config.yaml
+  core_service:
+    service_name: clashtui_mihomo
+    is_user: true
+    service_controller: systemd
+singbox:
+  core:
+    bin_path: <HOME_REPLACE>/.local/clashtui/sing-box/sing-box
+    config_dir: <HOME_REPLACE>/.local/clashtui/sing-box/config
+    config_path: <HOME_REPLACE>/.local/clashtui/sing-box/config/config.json
+  core_service:
+    service_name: clashtui_singbox
+    is_user: true
+    service_controller: systemd
+timeout: null
+extra:
+  edit_cmd:
+  open_dir_cmd:
+```
+
+> Replace `<HOME_REPLACE>` with your home directory path, e.g. `/home/johan`. Do not use `~` or `$HOME`.
+
+## 5. Create Core Configs
+
+```sh
+mkdir -p ~/.local/clashtui/mihomo/config
+mkdir -p ~/.local/clashtui/sing-box/config
+mkdir -p ~/.config/clashtui/mihomo
+mkdir -p ~/.config/clashtui/sing-box
+```
+
+Download core override configs from GitHub:
+
+```sh
+base="https://raw.githubusercontent.com/JohanChane/clashtui/main/contrib/default_configs"
+
+# Mihomo
+curl -o ~/.config/clashtui/mihomo/core_override_config.yaml \
+  "${base}/mihomo/core_override_config.yaml"
+cp ~/.config/clashtui/mihomo/core_override_config.yaml \
+  ~/.local/clashtui/mihomo/config/config.yaml
+
+# sing-box
+curl -o ~/.config/clashtui/sing-box/core_override_config.json \
+  "${base}/sing-box/core_override_config.json"
+cp ~/.config/clashtui/sing-box/core_override_config.json \
+  ~/.local/clashtui/sing-box/config/config.json
+```
+
+## 6. Download Default Files
+
+```sh
+curl -o ~/.config/clashtui/default_keymap.yaml \
+  "${base}/default_keymap.yaml"
+curl -o ~/.config/clashtui/default_theme.yaml \
+  "${base}/default_theme.yaml"
+```
+
+> User mode does **not** require creating system users and groups. Services run as the current user.
+
+## 7. Create systemd User Services
+
+**clashtui_mihomo** — write to `~/.config/systemd/user/clashtui_mihomo.service`:
+
+```sh
+mkdir -p ~/.config/systemd/user
+```
+
+```ini
+[Unit]
+Description=mihomo Daemon, Another Clash Kernel.
+After=network.target NetworkManager.service systemd-networkd.service iwd.service
+
+[Service]
+Type=simple
+LimitNPROC=500
+LimitNOFILE=1000000
+Restart=always
+ExecStartPre=/usr/bin/sleep 1s
+ExecStart=<HOME_REPLACE>/.local/clashtui/mihomo/mihomo -d <HOME_REPLACE>/.local/clashtui/mihomo/config
+ExecReload=/bin/kill -HUP $MAINPID
+
+[Install]
+WantedBy=default.target
+```
+
+**clashtui_singbox** — write to `~/.config/systemd/user/clashtui_singbox.service`:
+
+```ini
+[Unit]
+Description=sing-box Daemon, The universal proxy platform.
+After=network.target NetworkManager.service systemd-networkd.service iwd.service
+
+[Service]
+Type=simple
+ExecStartPre=/usr/bin/sleep 1s
+ExecStart=<HOME_REPLACE>/.local/clashtui/sing-box/sing-box -D <HOME_REPLACE>/.local/clashtui/sing-box/config -c <HOME_REPLACE>/.local/clashtui/sing-box/config/config.json run
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=on-failure
+RestartSec=10s
+LimitNOFILE=infinity
+
+[Install]
+WantedBy=default.target
+```
+
+> Replace `<HOME_REPLACE>` with your home directory path. In user mode, omit `User=` and `Group=`, and skip `CapabilityBoundingSet` and `AmbientCapabilities` (these require root privileges to take effect).
+
+Enable services:
+
+```sh
+systemctl --user daemon-reload
+systemctl --user enable clashtui_mihomo
+systemctl --user enable clashtui_singbox
+```
+
+> By default, user services stop on logout. To keep them running, run: `sudo loginctl enable-linger`
+
+## 8. Create Subscription Configs
+
+`~/.config/clashtui/mihomo/template_proxy_providers.yaml`:
+
+```yaml
+# Define proxy-provider subscription URLs here
+# pvd:
+#   pvd0: "https://example.com/sub.yaml"
+```
+
+Same for `~/.config/clashtui/sing-box/template_proxy_providers.yaml`.
+
+Create required directories:
+
+```sh
+mkdir -p ~/.config/clashtui/mihomo/{profiles,templates}
+mkdir -p ~/.config/clashtui/sing-box/{profiles,templates}
+```
+
+## 9. Download Rule Files (Optional)
+
+```sh
+curl -Lo ~/.local/clashtui/mihomo/config/geoip.metadb \
+  https://github.com/MetaCubeX/meta-rules-dat/releases/latest/download/geoip.metadb
+curl -Lo ~/.local/clashtui/mihomo/config/GeoSite.dat \
+  https://github.com/MetaCubeX/meta-rules-dat/releases/latest/download/geosite.dat
+```
+
+## 10. Launch
+
+```sh
+clashtui
+```
+
+## Uninstall
+
+```sh
+systemctl --user stop clashtui_mihomo clashtui_singbox
+rm -f ~/.config/systemd/user/clashtui_mihomo.service
+rm -f ~/.config/systemd/user/clashtui_singbox.service
+systemctl --user daemon-reload
+rm -rf ~/.local/clashtui
+rm -rf ~/.config/clashtui
+rm -rf ~/.cache/clashtui
+```

--- a/docs/install_manually_en.md
+++ b/docs/install_manually_en.md
@@ -425,8 +425,6 @@ After=network.target NetworkManager.service systemd-networkd.service iwd.service
 
 [Service]
 Type=simple
-LimitNPROC=500
-LimitNOFILE=1000000
 Restart=always
 ExecStartPre=/usr/bin/sleep 1s
 ExecStart=<HOME_REPLACE>/.local/clashtui/mihomo/mihomo -d <HOME_REPLACE>/.local/clashtui/mihomo/config

--- a/docs/install_manually_zh.md
+++ b/docs/install_manually_zh.md
@@ -1,6 +1,10 @@
 # ClashTui 手动安装指南
 
-以 Arch Linux, amd64, systemd (system 模式) 为例。
+以 Arch Linux, amd64, systemd 为例。下面分别给出 system 模式和 user 模式的步骤。
+
+---
+
+# System 模式
 
 ## 目录布局
 
@@ -262,4 +266,250 @@ rm -rf ~/.config/clashtui
 rm -rf ~/.cache/clashtui
 sudo userdel mihomo
 sudo userdel sing-box
+```
+
+---
+
+# User 模式
+
+无需 root 权限安装到 `~/.local/clashtui/`，服务以当前用户身份运行。
+
+## 目录布局
+
+```
+~/.local/clashtui/
+├── bin/
+│   └── clashtui
+├── mihomo/
+│   ├── mihomo
+│   └── config/
+│       └── config.yaml
+└── sing-box/
+    ├── sing-box
+    └── config/
+        └── config.json
+
+~/.config/clashtui/
+├── config.yaml
+├── default_keymap.yaml
+├── default_theme.yaml
+├── mihomo/
+│   ├── core_override_config.yaml
+│   ├── template_proxy_providers.yaml
+│   ├── profiles/
+│   └── templates/
+└── sing-box/
+    ├── core_override_config.json
+    ├── template_proxy_providers.yaml
+    ├── profiles/
+    └── templates/
+```
+
+## 1. 下载 ClashTui
+
+```sh
+curl -LO "https://github.com/JohanChane/clashtui/releases/latest/download/clashtui-linux-amd64-$(curl -s https://api.github.com/repos/JohanChane/clashtui/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/').gz"
+gunzip clashtui-linux-amd64-*.gz
+chmod +x clashtui-linux-amd64-*
+mkdir -p ~/.local/clashtui/bin
+install -m 755 clashtui-linux-amd64-* ~/.local/clashtui/bin/clashtui
+ln -sf ~/.local/clashtui/bin/clashtui ~/.local/bin/clashtui
+```
+
+## 2. 下载 Mihomo
+
+```sh
+mihomo_ver=$(curl -s https://api.github.com/repos/MetaCubeX/mihomo/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+curl -L "https://github.com/MetaCubeX/mihomo/releases/latest/download/mihomo-linux-amd64-${mihomo_ver}.gz" -o /tmp/mihomo.gz
+gunzip -c /tmp/mihomo.gz > /tmp/mihomo
+mkdir -p ~/.local/clashtui/mihomo
+install -m 755 /tmp/mihomo ~/.local/clashtui/mihomo/mihomo
+```
+
+## 3. 下载 sing-box
+
+```sh
+sb_ver=$(curl -s https://api.github.com/repos/SagerNet/sing-box/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+curl -L "https://github.com/SagerNet/sing-box/releases/latest/download/sing-box-${sb_ver}-linux-amd64.tar.gz" -o /tmp/sing-box.tar.gz
+tar -xzf /tmp/sing-box.tar.gz -C /tmp/
+mkdir -p ~/.local/clashtui/sing-box
+install -m 755 /tmp/sing-box-*/sing-box ~/.local/clashtui/sing-box/sing-box
+ln -sf ~/.local/clashtui/sing-box/sing-box ~/.local/bin/sing-box
+```
+
+## 4. 创建 ClashTui 主配置
+
+```sh
+mkdir -p ~/.config/clashtui
+```
+
+`~/.config/clashtui/config.yaml`:
+
+```yaml
+mihomo:
+  core:
+    config_dir: <HOME_REPLACE>/.local/clashtui/mihomo/config
+    bin_path: <HOME_REPLACE>/.local/clashtui/mihomo/mihomo
+    config_path: <HOME_REPLACE>/.local/clashtui/mihomo/config/config.yaml
+  core_service:
+    service_name: clashtui_mihomo
+    is_user: true
+    service_controller: systemd
+singbox:
+  core:
+    bin_path: <HOME_REPLACE>/.local/clashtui/sing-box/sing-box
+    config_dir: <HOME_REPLACE>/.local/clashtui/sing-box/config
+    config_path: <HOME_REPLACE>/.local/clashtui/sing-box/config/config.json
+  core_service:
+    service_name: clashtui_singbox
+    is_user: true
+    service_controller: systemd
+timeout: null
+extra:
+  edit_cmd:
+  open_dir_cmd:
+```
+
+> 将 `<HOME_REPLACE>` 替换为你的 home 目录路径, 如 `/home/johan`。不能使用 `~` 或 `$HOME`。
+
+## 5. 创建 Core 配置
+
+```sh
+mkdir -p ~/.local/clashtui/mihomo/config
+mkdir -p ~/.local/clashtui/sing-box/config
+mkdir -p ~/.config/clashtui/mihomo
+mkdir -p ~/.config/clashtui/sing-box
+```
+
+从 GitHub 下载 core override 配置:
+
+```sh
+base="https://raw.githubusercontent.com/JohanChane/clashtui/main/contrib/default_configs"
+
+# Mihomo
+curl -o ~/.config/clashtui/mihomo/core_override_config.yaml \
+  "${base}/mihomo/core_override_config.yaml"
+cp ~/.config/clashtui/mihomo/core_override_config.yaml \
+  ~/.local/clashtui/mihomo/config/config.yaml
+
+# sing-box
+curl -o ~/.config/clashtui/sing-box/core_override_config.json \
+  "${base}/sing-box/core_override_config.json"
+cp ~/.config/clashtui/sing-box/core_override_config.json \
+  ~/.local/clashtui/sing-box/config/config.json
+```
+
+## 6. 下载默认文件
+
+```sh
+curl -o ~/.config/clashtui/default_keymap.yaml \
+  "${base}/default_keymap.yaml"
+curl -o ~/.config/clashtui/default_theme.yaml \
+  "${base}/default_theme.yaml"
+```
+
+> User 模式**不需要**创建系统用户和组。服务以当前用户身份运行。
+
+## 7. 创建 systemd user 服务
+
+**clashtui_mihomo** — 写入 `~/.config/systemd/user/clashtui_mihomo.service`:
+
+```sh
+mkdir -p ~/.config/systemd/user
+```
+
+```ini
+[Unit]
+Description=mihomo Daemon, Another Clash Kernel.
+After=network.target NetworkManager.service systemd-networkd.service iwd.service
+
+[Service]
+Type=simple
+LimitNPROC=500
+LimitNOFILE=1000000
+Restart=always
+ExecStartPre=/usr/bin/sleep 1s
+ExecStart=<HOME_REPLACE>/.local/clashtui/mihomo/mihomo -d <HOME_REPLACE>/.local/clashtui/mihomo/config
+ExecReload=/bin/kill -HUP $MAINPID
+
+[Install]
+WantedBy=default.target
+```
+
+**clashtui_singbox** — 写入 `~/.config/systemd/user/clashtui_singbox.service`:
+
+```ini
+[Unit]
+Description=sing-box Daemon, The universal proxy platform.
+After=network.target NetworkManager.service systemd-networkd.service iwd.service
+
+[Service]
+Type=simple
+ExecStartPre=/usr/bin/sleep 1s
+ExecStart=<HOME_REPLACE>/.local/clashtui/sing-box/sing-box -D <HOME_REPLACE>/.local/clashtui/sing-box/config -c <HOME_REPLACE>/.local/clashtui/sing-box/config/config.json run
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=on-failure
+RestartSec=10s
+LimitNOFILE=infinity
+
+[Install]
+WantedBy=default.target
+```
+
+> 将 `<HOME_REPLACE>` 替换为你的 home 目录路径。User 模式下**不填** `User=` 和 `Group=`, 也不需要 `CapabilityBoundingSet` 和 `AmbientCapabilities`（这些需要 root 权限才生效）。
+
+启用服务:
+
+```sh
+systemctl --user daemon-reload
+systemctl --user enable clashtui_mihomo
+systemctl --user enable clashtui_singbox
+```
+
+> 默认情况下, user 服务在注销后会停止。如果需要保持运行, 执行: `sudo loginctl enable-linger`
+
+## 8. 创建订阅配置
+
+`~/.config/clashtui/mihomo/template_proxy_providers.yaml`:
+
+```yaml
+# 定义代理提供者的订阅 URL
+# pvd:
+#   pvd0: "https://example.com/sub.yaml"
+```
+
+`~/.config/clashtui/sing-box/template_proxy_providers.yaml` 同理。
+
+创建必要的目录:
+
+```sh
+mkdir -p ~/.config/clashtui/mihomo/{profiles,templates}
+mkdir -p ~/.config/clashtui/sing-box/{profiles,templates}
+```
+
+## 9. 下载规则文件 (可选)
+
+```sh
+curl -Lo ~/.local/clashtui/mihomo/config/geoip.metadb \
+  https://github.com/MetaCubeX/meta-rules-dat/releases/latest/download/geoip.metadb
+curl -Lo ~/.local/clashtui/mihomo/config/GeoSite.dat \
+  https://github.com/MetaCubeX/meta-rules-dat/releases/latest/download/geosite.dat
+```
+
+## 10. 启动
+
+```sh
+clashtui
+```
+
+## 卸载
+
+```sh
+systemctl --user stop clashtui_mihomo clashtui_singbox
+rm -f ~/.config/systemd/user/clashtui_mihomo.service
+rm -f ~/.config/systemd/user/clashtui_singbox.service
+systemctl --user daemon-reload
+rm -rf ~/.local/clashtui
+rm -rf ~/.config/clashtui
+rm -rf ~/.cache/clashtui
 ```

--- a/docs/install_manually_zh.md
+++ b/docs/install_manually_zh.md
@@ -1,0 +1,265 @@
+# ClashTui 手动安装指南
+
+以 Arch Linux, amd64, systemd (system 模式) 为例。
+
+## 目录布局
+
+安装后的目录结构:
+
+```
+/opt/clashtui/
+├── bin/
+│   └── clashtui
+├── mihomo/
+│   ├── mihomo
+│   └── config/
+│       └── config.yaml
+└── sing-box/
+    ├── sing-box
+    └── config/
+        └── config.json
+
+~/.config/clashtui/
+├── config.yaml
+├── default_keymap.yaml
+├── default_theme.yaml
+├── mihomo/
+│   ├── core_override_config.yaml
+│   ├── template_proxy_providers.yaml
+│   ├── profiles/
+│   └── templates/
+└── sing-box/
+    ├── core_override_config.json
+    ├── template_proxy_providers.yaml
+    ├── profiles/
+    └── templates/
+```
+
+## 1. 下载 ClashTui
+
+```sh
+curl -LO "https://github.com/JohanChane/clashtui/releases/latest/download/clashtui-linux-amd64-$(curl -s https://api.github.com/repos/JohanChane/clashtui/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/').gz"
+gunzip clashtui-linux-amd64-*.gz
+chmod +x clashtui-linux-amd64-*
+sudo mkdir -p /opt/clashtui/bin
+sudo install -m 755 clashtui-linux-amd64-* /opt/clashtui/bin/clashtui
+sudo ln -sf /opt/clashtui/bin/clashtui /usr/local/bin/clashtui
+```
+
+## 2. 下载 Mihomo
+
+```sh
+mihomo_ver=$(curl -s https://api.github.com/repos/MetaCubeX/mihomo/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+curl -L "https://github.com/MetaCubeX/mihomo/releases/latest/download/mihomo-linux-amd64-${mihomo_ver}.gz" -o /tmp/mihomo.gz
+gunzip -c /tmp/mihomo.gz > /tmp/mihomo
+sudo mkdir -p /opt/clashtui/mihomo
+sudo install -m 755 /tmp/mihomo /opt/clashtui/mihomo/mihomo
+```
+
+## 3. 下载 sing-box
+
+```sh
+sb_ver=$(curl -s https://api.github.com/repos/SagerNet/sing-box/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+curl -L "https://github.com/SagerNet/sing-box/releases/latest/download/sing-box-${sb_ver}-linux-amd64.tar.gz" -o /tmp/sing-box.tar.gz
+tar -xzf /tmp/sing-box.tar.gz -C /tmp/
+sudo mkdir -p /opt/clashtui/sing-box
+sudo install -m 755 /tmp/sing-box-*/sing-box /opt/clashtui/sing-box/sing-box
+sudo ln -sf /opt/clashtui/sing-box/sing-box /usr/bin/sing-box
+```
+
+## 4. 创建 ClashTui 主配置
+
+```sh
+mkdir -p ~/.config/clashtui
+```
+
+`~/.config/clashtui/config.yaml`:
+
+```yaml
+mihomo:
+  core:
+    config_dir: /opt/clashtui/mihomo/config
+    bin_path: /opt/clashtui/mihomo/mihomo
+    config_path: /opt/clashtui/mihomo/config/config.yaml
+  core_service:
+    service_name: clashtui_mihomo
+    is_user: false
+    service_controller: systemd
+singbox:
+  core:
+    bin_path: /opt/clashtui/sing-box/sing-box
+    config_dir: /opt/clashtui/sing-box/config
+    config_path: /opt/clashtui/sing-box/config/config.json
+  core_service:
+    service_name: clashtui_singbox
+    is_user: false
+    service_controller: systemd
+timeout: null
+extra:
+  edit_cmd:
+  open_dir_cmd:
+```
+
+## 5. 创建 Core 配置
+
+```sh
+sudo mkdir -p /opt/clashtui/mihomo/config
+sudo mkdir -p /opt/clashtui/sing-box/config
+mkdir -p ~/.config/clashtui/mihomo
+mkdir -p ~/.config/clashtui/sing-box
+```
+
+从 GitHub 下载 core override 配置:
+
+```sh
+base="https://raw.githubusercontent.com/JohanChane/clashtui/main/contrib/default_configs"
+
+# Mihomo
+curl -o ~/.config/clashtui/mihomo/core_override_config.yaml \
+  "${base}/mihomo/core_override_config.yaml"
+sudo cp ~/.config/clashtui/mihomo/core_override_config.yaml \
+  /opt/clashtui/mihomo/config/config.yaml
+
+# sing-box
+curl -o ~/.config/clashtui/sing-box/core_override_config.json \
+  "${base}/sing-box/core_override_config.json"
+sudo cp ~/.config/clashtui/sing-box/core_override_config.json \
+  /opt/clashtui/sing-box/config/config.json
+```
+
+## 6. 下载默认文件
+
+```sh
+curl -o ~/.config/clashtui/default_keymap.yaml \
+  "${base}/default_keymap.yaml"
+curl -o ~/.config/clashtui/default_theme.yaml \
+  "${base}/default_theme.yaml"
+```
+
+## 7. 创建用户、权限
+
+```sh
+sudo groupadd --system mihomo
+sudo useradd --system --no-create-home --gid mihomo --shell /bin/false mihomo
+sudo groupadd --system sing-box
+sudo useradd --system --no-create-home --gid sing-box --shell /bin/false sing-box
+
+sudo gpasswd -a $USER mihomo
+sudo gpasswd -a $USER sing-box
+
+# 将用户加入组后, 需要重新登录才能生效
+
+sudo chown -R mihomo:mihomo /opt/clashtui/mihomo
+sudo chmod g+rwxs /opt/clashtui/mihomo/config
+sudo chown -R sing-box:sing-box /opt/clashtui/sing-box
+sudo chmod g+rwxs /opt/clashtui/sing-box/config
+```
+
+## 8. 创建 systemd 服务
+
+**clashtui_mihomo** — 写入 `/opt/clashtui/mihomo/clashtui_mihomo.service`:
+
+```ini
+[Unit]
+Description=mihomo Daemon, Another Clash Kernel.
+After=network.target NetworkManager.service systemd-networkd.service iwd.service
+
+[Service]
+Type=simple
+User=mihomo
+Group=mihomo
+LimitNPROC=500
+LimitNOFILE=1000000
+CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_RAW CAP_NET_BIND_SERVICE CAP_SYS_TIME CAP_SYS_PTRACE CAP_DAC_READ_SEARCH CAP_DAC_OVERRIDE
+AmbientCapabilities=CAP_NET_ADMIN CAP_NET_RAW CAP_NET_BIND_SERVICE CAP_SYS_TIME CAP_SYS_PTRACE CAP_DAC_READ_SEARCH CAP_DAC_OVERRIDE
+Restart=always
+ExecStartPre=/usr/bin/sleep 1s
+ExecStart=/opt/clashtui/mihomo/mihomo -d /opt/clashtui/mihomo/config
+ExecReload=/bin/kill -HUP $MAINPID
+
+[Install]
+WantedBy=multi-user.target
+```
+
+**clashtui_singbox** — 写入 `/opt/clashtui/sing-box/clashtui_singbox.service`:
+
+```ini
+[Unit]
+Description=sing-box Daemon, The universal proxy platform.
+After=network.target NetworkManager.service systemd-networkd.service iwd.service
+
+[Service]
+Type=simple
+User=sing-box
+Group=sing-box
+StateDirectory=sing-box
+CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_RAW CAP_NET_BIND_SERVICE CAP_SYS_PTRACE CAP_DAC_READ_SEARCH
+AmbientCapabilities=CAP_NET_ADMIN CAP_NET_RAW CAP_NET_BIND_SERVICE CAP_SYS_PTRACE CAP_DAC_READ_SEARCH
+ExecStartPre=/usr/bin/sleep 1s
+ExecStart=/usr/bin/sing-box -D /opt/clashtui/sing-box/config -c /opt/clashtui/sing-box/config/config.json run
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=on-failure
+RestartSec=10s
+LimitNOFILE=infinity
+
+[Install]
+WantedBy=multi-user.target
+```
+
+启用服务:
+
+```sh
+sudo ln -sf /opt/clashtui/mihomo/clashtui_mihomo.service /usr/lib/systemd/system/
+sudo ln -sf /opt/clashtui/sing-box/clashtui_singbox.service /usr/lib/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable clashtui_mihomo
+sudo systemctl enable clashtui_singbox
+```
+
+## 9. 创建订阅配置
+
+`~/.config/clashtui/mihomo/template_proxy_providers.yaml`:
+
+```yaml
+# 定义代理提供者的订阅 URL
+# pvd:
+#   pvd0: "https://example.com/sub.yaml"
+```
+
+`~/.config/clashtui/sing-box/template_proxy_providers.yaml` 同理。
+
+创建必要的目录:
+
+```sh
+mkdir -p ~/.config/clashtui/mihomo/{profiles,templates}
+mkdir -p ~/.config/clashtui/sing-box/{profiles,templates}
+```
+
+## 10. 下载规则文件 (可选)
+
+```sh
+curl -Lo /opt/clashtui/mihomo/config/geoip.metadb \
+  https://github.com/MetaCubeX/meta-rules-dat/releases/latest/download/geoip.metadb
+curl -Lo /opt/clashtui/mihomo/config/GeoSite.dat \
+  https://github.com/MetaCubeX/meta-rules-dat/releases/latest/download/geosite.dat
+```
+
+## 11. 启动
+
+```sh
+clashtui
+```
+
+## 卸载
+
+```sh
+sudo systemctl stop clashtui_mihomo clashtui_singbox
+sudo rm -f /usr/lib/systemd/system/clashtui_mihomo.service
+sudo rm -f /usr/lib/systemd/system/clashtui_singbox.service
+sudo systemctl daemon-reload
+sudo rm -rf /opt/clashtui
+rm -rf ~/.config/clashtui
+rm -rf ~/.cache/clashtui
+sudo userdel mihomo
+sudo userdel sing-box
+```

--- a/installs/install
+++ b/installs/install
@@ -33,6 +33,16 @@ command_exists() {
   command -v "$1" >/dev/null 2>&1
 }
 
+backup_dir() {
+  [ -d "$1" ] || return 0
+  local i=1
+  while [ -d "${1}_$i" ]; do
+    ((i++))
+  done
+  cp -r "$1" "${1}_$i"
+  log_info "Backed up directory: $1 -> ${1}_$i"
+}
+
 backup_file() {
   [ -e "$1" ] || return 1
   local i=1
@@ -764,6 +774,7 @@ create_core_configs() {
   log_info "Creating core config files..."
 
   if [ "$core_type" = "mihomo" ] || [ "$core_type" = "all" ]; then
+    backup_dir "$MIHOMO_CONFIG_DIR"
     $SUDO mkdir -p "$MIHOMO_CONFIG_DIR"
 
     local mihomo_cfg_src
@@ -778,6 +789,7 @@ create_core_configs() {
     log_info "Mihomo core config written to: ${MIHOMO_CONFIG_DIR}/config.yaml"
 
     # Also copy to clashtui config dir for profile management
+    backup_dir "$MIHOMO_USER_CONFIG_DIR"
     mkdir -p "$MIHOMO_USER_CONFIG_DIR"
     copy_contrib "$mihomo_cfg_src" "${MIHOMO_USER_CONFIG_DIR}/core_override_config.yaml"
     log_info "Mihomo core override written to: ${MIHOMO_USER_CONFIG_DIR}/core_override_config.yaml"
@@ -793,6 +805,7 @@ create_core_configs() {
   fi
 
   if [ "$core_type" = "sing-box" ] || [ "$core_type" = "all" ]; then
+    backup_dir "$SINGBOX_CONFIG_DIR"
     $SUDO mkdir -p "$SINGBOX_CONFIG_DIR"
 
     local singbox_cfg_src
@@ -806,6 +819,7 @@ create_core_configs() {
     log_info "Sing-box core config written to: ${SINGBOX_CONFIG_DIR}/config.json"
 
     # Also copy to clashtui config dir for profile management
+    backup_dir "$SINGBOX_USER_CONFIG_DIR"
     mkdir -p "$SINGBOX_USER_CONFIG_DIR"
     copy_contrib "$singbox_cfg_src" "${SINGBOX_USER_CONFIG_DIR}/core_override_config.json"
     log_info "Sing-box core override written to: ${SINGBOX_USER_CONFIG_DIR}/core_override_config.json"
@@ -826,6 +840,7 @@ create_clashtui_config() {
   local core_type="$1"
   log_info "Creating clashtui config..."
 
+  backup_dir "$CLASHTUI_CONFIG_DIR"
   mkdir -p "$CLASHTUI_CONFIG_DIR"
 
   # Copy contrib default_keymap.yaml and default_theme.yaml
@@ -834,8 +849,6 @@ create_clashtui_config() {
   log_info "Copied default configs to: $CLASHTUI_CONFIG_DIR"
 
   # Generate single config.yaml with both core sections
-  backup_file "$CLASHTUI_CONFIG_DIR/config.yaml"
-
   cat >"$CLASHTUI_CONFIG_DIR/config.yaml" <<EOF
 mihomo:
   core:

--- a/installs/install
+++ b/installs/install
@@ -6,6 +6,7 @@ IS_TEST=false
 REPO="JohanChane/clashtui"
 BRANCH="main"
 CORE_TYPE="all"
+SERVICE_CONTROLLER="systemd"
 
 # --- Constants (canonical upstreams) ---
 MIHOMO_UPSTREAM="MetaCubeX/mihomo"
@@ -45,6 +46,11 @@ backup_file() {
 resolve_paths() {
   detect_is_macos
 
+  if [ "$SERVICE_CONTROLLER" = "openrc" ] && $IS_USER; then
+    log_warn "OpenRC does not support user services; ignoring --is-user flag"
+    IS_USER=false
+  fi
+
   if $IS_USER; then
     INSTALL_DIR="$HOME/.local/clashtui"
     INSTALL_DIR_MIHOMO="$INSTALL_DIR/mihomo"
@@ -79,14 +85,19 @@ resolve_paths() {
       LAUNCHD_DOMAIN="system"
     else
       INSTALL_DIR="/opt/clashtui"
-      UNIT_DIR="/usr/lib/systemd/system"
       SUDO="sudo"
-      SYSTEMCTL_FLAGS=""
-      SYSTEMD_RELOAD="sudo systemctl daemon-reload"
-      UNIT_WANTED_BY="multi-user.target"
       SERVICE_LOAD_CMD=""
       SERVICE_UNLOAD_CMD=""
-      SERVICE_ENABLE_CMD="sudo systemctl enable"
+      if [ "$SERVICE_CONTROLLER" = "openrc" ]; then
+        UNIT_DIR="/etc/init.d"
+        SERVICE_ENABLE_CMD="sudo rc-update add"
+      else
+        UNIT_DIR="/usr/lib/systemd/system"
+        SYSTEMCTL_FLAGS=""
+        SYSTEMD_RELOAD="sudo systemctl daemon-reload"
+        UNIT_WANTED_BY="multi-user.target"
+        SERVICE_ENABLE_CMD="sudo systemctl enable"
+      fi
     fi
     INSTALL_DIR_MIHOMO="$INSTALL_DIR/mihomo"
     INSTALL_DIR_SINGBOX="$INSTALL_DIR/sing-box"
@@ -516,6 +527,27 @@ EOF
     if [ -n "$SERVICE_LOAD_CMD" ]; then
       $SERVICE_LOAD_CMD "$plist_path"
     fi
+  elif [ "$SERVICE_CONTROLLER" = "openrc" ]; then
+    # ── Linux: OpenRC init script ──
+    log_info "Creating mihomo OpenRC init script..."
+    local init_path="$UNIT_DIR/${service_name}"
+    $SUDO tee "$init_path" >/dev/null <<EOF
+#!/sbin/openrc-run
+
+supervisor="supervise-daemon"
+name="${service_name}"
+description="mihomo Daemon, Another Clash Kernel."
+command="${INSTALL_DIR_MIHOMO}/mihomo"
+command_args="-d ${MIHOMO_CONFIG_DIR}"
+command_user="mihomo:mihomo"
+pidfile="/run/\${RC_SVCNAME}.pid"
+
+depend() {
+    need net
+}
+EOF
+    $SUDO chmod +x "$init_path"
+    log_info "Created OpenRC init script: $init_path"
   else
     # ── Linux: systemd unit ──
     log_info "Creating mihomo systemd unit..."
@@ -628,6 +660,27 @@ EOF
     if [ -n "$SERVICE_LOAD_CMD" ]; then
       $SERVICE_LOAD_CMD "$plist_path"
     fi
+  elif [ "$SERVICE_CONTROLLER" = "openrc" ]; then
+    # ── Linux: OpenRC init script ──
+    log_info "Creating sing-box OpenRC init script..."
+    local init_path="$UNIT_DIR/${service_name}"
+    $SUDO tee "$init_path" >/dev/null <<EOF
+#!/sbin/openrc-run
+
+supervisor="supervise-daemon"
+name="${service_name}"
+description="sing-box Daemon, The universal proxy platform."
+command="/usr/bin/sing-box"
+command_args="-D ${SINGBOX_CONFIG_DIR} -c ${SINGBOX_CONFIG_DIR}/config.json run"
+command_user="sing-box:sing-box"
+pidfile="/run/\${RC_SVCNAME}.pid"
+
+depend() {
+    need net
+}
+EOF
+    $SUDO chmod +x "$init_path"
+    log_info "Created OpenRC init script: $init_path"
   else
     # ── Linux: systemd unit ──
     log_info "Creating sing-box systemd unit..."
@@ -776,6 +829,7 @@ mihomo:
   core_service:
     service_name: clashtui_mihomo
     is_user: ${SERVICE_IS_USER}
+    service_controller: ${SERVICE_CONTROLLER}
 singbox:
   core:
     bin_path: ${INSTALL_DIR_SINGBOX}/sing-box
@@ -784,6 +838,7 @@ singbox:
   core_service:
     service_name: clashtui_singbox
     is_user: ${SERVICE_IS_USER}
+    service_controller: ${SERVICE_CONTROLLER}
 timeout:
 extra:
   edit_cmd:
@@ -994,9 +1049,18 @@ uninstall() {
       echo "  sudo rm -f /usr/local/var/log/clashtui_mihomo.log"
       echo "  sudo rm -f /usr/local/var/log/clashtui_singbox.log"
     else
-      sudo rm -f /usr/lib/systemd/system/clashtui_mihomo.service
-      sudo rm -f /usr/lib/systemd/system/clashtui_singbox.service
-      sudo systemctl daemon-reload
+      if [ "$SERVICE_CONTROLLER" = "openrc" ]; then
+        sudo rc-service clashtui_mihomo stop 2>/dev/null
+        sudo rc-service clashtui_singbox stop 2>/dev/null
+        sudo rc-update del clashtui_mihomo default 2>/dev/null
+        sudo rc-update del clashtui_singbox default 2>/dev/null
+        sudo rm -f /etc/init.d/clashtui_mihomo
+        sudo rm -f /etc/init.d/clashtui_singbox
+      else
+        sudo rm -f /usr/lib/systemd/system/clashtui_mihomo.service
+        sudo rm -f /usr/lib/systemd/system/clashtui_singbox.service
+        sudo systemctl daemon-reload
+      fi
       sudo rm -rf /opt/clashtui
 
       echo "[Optional] Delete the mihomo user and group"
@@ -1023,6 +1087,7 @@ show_help() {
   echo "  --repo <R>       GitHub repo for clashtui and contrib (default: $REPO)"
   echo "  --branch <B>     Branch for contrib resources (default: $BRANCH)"
   echo "  --core <TYPE>    Select core: mihomo, sing-box, or all (default: all)"
+  echo "  --service-controller <CTRL>  Init system: systemd or openrc (default: systemd)"
   echo
   echo "When --is-user is set:"
   echo "  - Installs to ~/.local/clashtui"
@@ -1033,6 +1098,10 @@ show_help() {
   fi
   echo "  - Uses no-TUN core configs (TUN requires root capabilities)"
   echo "  - Skips creating system users/groups"
+  echo
+  echo "When --service-controller openrc is set on Linux:"
+  echo "  - Creates OpenRC init scripts in /etc/init.d/"
+  echo "  - --is-user is ignored (OpenRC does not support user services)"
   echo
   echo "If no options are provided, the script will install clashtui with all cores"
   if $IS_MACOS; then
@@ -1086,6 +1155,22 @@ main() {
         ;;
       *)
         log_error "Invalid core type: $2. Valid values: mihomo, sing-box, all"
+        exit 1
+        ;;
+      esac
+      ;;
+    --service-controller)
+      if [ -z "$2" ]; then
+        log_error "--service-controller requires a value: systemd or openrc"
+        exit 1
+      fi
+      case "$2" in
+      systemd | openrc)
+        SERVICE_CONTROLLER="$2"
+        shift
+        ;;
+      *)
+        log_error "Invalid service controller: $2. Valid values: systemd, openrc"
         exit 1
         ;;
       esac
@@ -1170,10 +1255,19 @@ main() {
       log_info "  Start + autostart: sudo launchctl load -w /Library/LaunchDaemons/clashtui_mihomo.plist"
       log_info "  Stop + disable:    sudo launchctl unload /Library/LaunchDaemons/clashtui_mihomo.plist"
     else
-      log_info "System mode: unit files created in /usr/lib/systemd/system/"
-      log_info "Services are NOT started automatically. Use these commands:"
-      log_info "  Start now:         sudo systemctl start clashtui_mihomo"
-      log_info "  Start + autostart: sudo systemctl enable --now clashtui_mihomo"
+      if [ "$SERVICE_CONTROLLER" = "openrc" ]; then
+        log_info "System mode (OpenRC): init scripts created in /etc/init.d/"
+        log_info "Services are NOT started automatically. Use these commands:"
+        log_info "  Start now:         sudo rc-service clashtui_mihomo start"
+        log_info "  Start + autostart: sudo rc-update add clashtui_mihomo default && sudo rc-service clashtui_mihomo start"
+        log_info "  Stop:              sudo rc-service clashtui_mihomo stop"
+        log_info "  Disable autostart: sudo rc-update del clashtui_mihomo default"
+      else
+        log_info "System mode: unit files created in /usr/lib/systemd/system/"
+        log_info "Services are NOT started automatically. Use these commands:"
+        log_info "  Start now:         sudo systemctl start clashtui_mihomo"
+        log_info "  Start + autostart: sudo systemctl enable --now clashtui_mihomo"
+      fi
     fi
   fi
 }

--- a/installs/install
+++ b/installs/install
@@ -46,11 +46,6 @@ backup_file() {
 resolve_paths() {
   detect_is_macos
 
-  if [ "$SERVICE_CONTROLLER" = "openrc" ] && $IS_USER; then
-    log_warn "OpenRC does not support user services; ignoring --is-user flag"
-    IS_USER=false
-  fi
-
   if $IS_USER; then
     INSTALL_DIR="$HOME/.local/clashtui"
     INSTALL_DIR_MIHOMO="$INSTALL_DIR/mihomo"
@@ -65,6 +60,11 @@ resolve_paths() {
       SERVICE_UNLOAD_CMD="launchctl unload"
       SERVICE_ENABLE_CMD="launchctl load -w"
       LAUNCHD_DOMAIN="gui/\$(id -u)"
+    elif [ "$SERVICE_CONTROLLER" = "openrc" ]; then
+      UNIT_DIR="/etc/user/init.d"
+      SERVICE_LOAD_CMD=""
+      SERVICE_UNLOAD_CMD=""
+      SERVICE_ENABLE_CMD="rc-update --user add"
     else
       SYSTEMCTL_FLAGS="--user"
       UNIT_DIR="$HOME/.config/systemd/user"
@@ -539,8 +539,14 @@ name="${service_name}"
 description="mihomo Daemon, Another Clash Kernel."
 command="${INSTALL_DIR_MIHOMO}/mihomo"
 command_args="-d ${MIHOMO_CONFIG_DIR}"
+EOF
+    if ! $IS_USER; then
+      $SUDO tee -a "$init_path" >/dev/null <<EOF
 command_user="mihomo:mihomo"
 pidfile="/run/\${RC_SVCNAME}.pid"
+EOF
+    fi
+    $SUDO tee -a "$init_path" >/dev/null <<EOF
 
 depend() {
     need net
@@ -664,16 +670,28 @@ EOF
     # ── Linux: OpenRC init script ──
     log_info "Creating sing-box OpenRC init script..."
     local init_path="$UNIT_DIR/${service_name}"
+    local singbox_cmd
+    if $IS_USER; then
+      singbox_cmd="${INSTALL_DIR_SINGBOX}/sing-box"
+    else
+      singbox_cmd="/usr/bin/sing-box"
+    fi
     $SUDO tee "$init_path" >/dev/null <<EOF
 #!/sbin/openrc-run
 
 supervisor="supervise-daemon"
 name="${service_name}"
 description="sing-box Daemon, The universal proxy platform."
-command="/usr/bin/sing-box"
+command="${singbox_cmd}"
 command_args="-D ${SINGBOX_CONFIG_DIR} -c ${SINGBOX_CONFIG_DIR}/config.json run"
+EOF
+    if ! $IS_USER; then
+      $SUDO tee -a "$init_path" >/dev/null <<EOF
 command_user="sing-box:sing-box"
 pidfile="/run/\${RC_SVCNAME}.pid"
+EOF
+    fi
+    $SUDO tee -a "$init_path" >/dev/null <<EOF
 
 depend() {
     need net
@@ -1033,9 +1051,18 @@ uninstall() {
       rm -f "$UNIT_DIR/clashtui_mihomo.plist"
       rm -f "$UNIT_DIR/clashtui_singbox.plist"
     else
-      rm -f "$UNIT_DIR/clashtui_mihomo.service"
-      rm -f "$UNIT_DIR/clashtui_singbox.service"
-      systemctl --user daemon-reload
+      if [ "$SERVICE_CONTROLLER" = "openrc" ]; then
+        rc-service --user clashtui_mihomo stop 2>/dev/null
+        rc-service --user clashtui_singbox stop 2>/dev/null
+        rc-update --user del clashtui_mihomo default 2>/dev/null
+        rc-update --user del clashtui_singbox default 2>/dev/null
+        sudo rm -f "$UNIT_DIR/clashtui_mihomo"
+        sudo rm -f "$UNIT_DIR/clashtui_singbox"
+      else
+        rm -f "$UNIT_DIR/clashtui_mihomo.service"
+        rm -f "$UNIT_DIR/clashtui_singbox.service"
+        systemctl --user daemon-reload
+      fi
     fi
     rm -rf "$INSTALL_DIR"
   else
@@ -1094,14 +1121,15 @@ show_help() {
   if $IS_MACOS; then
     echo "  - Uses user-scoped launchd plists (~/Library/LaunchAgents)"
   else
-    echo "  - Uses user-scoped systemd units (systemctl --user)"
+    echo "  - Uses user-scoped units (systemctl --user or /etc/user/init.d for openrc)"
   fi
   echo "  - Uses no-TUN core configs (TUN requires root capabilities)"
   echo "  - Skips creating system users/groups"
   echo
   echo "When --service-controller openrc is set on Linux:"
-  echo "  - Creates OpenRC init scripts in /etc/init.d/"
-  echo "  - --is-user is ignored (OpenRC does not support user services)"
+  echo "  - System mode: creates OpenRC init scripts in /etc/init.d/"
+  echo "  - User mode:   creates OpenRC init scripts in /etc/user/init.d/"
+  echo "  - User mode requires XDG_RUNTIME_DIR (e.g. via elogind or shell rc)"
   echo
   echo "If no options are provided, the script will install clashtui with all cores"
   if $IS_MACOS; then
@@ -1241,11 +1269,21 @@ main() {
       log_info "  Stop + disable:    launchctl unload ~/Library/LaunchAgents/clashtui_mihomo.plist"
       log_warn "Services will stop when you log out. To keep them running, keep the session active."
     else
-      log_info "User mode: unit files created in ~/.config/systemd/user/"
-      log_info "Services are NOT started automatically. Use these commands:"
-      log_info "  Start now:         systemctl --user start clashtui_mihomo"
-      log_info "  Start + autostart: systemctl --user enable --now clashtui_mihomo"
-      log_warn "To keep services running after logout, run: loginctl enable-linger"
+      if [ "$SERVICE_CONTROLLER" = "openrc" ]; then
+        log_info "User mode (OpenRC): init scripts created in /etc/user/init.d/"
+        log_info "Services are NOT started automatically. Use these commands:"
+        log_info "  Start now:         rc-service --user clashtui_mihomo start"
+        log_info "  Start + autostart: rc-update --user add clashtui_mihomo default && rc-service --user clashtui_mihomo start"
+        log_info "  Stop:              rc-service --user clashtui_mihomo stop"
+        log_info "  Disable autostart: rc-update --user del clashtui_mihomo default"
+        log_warn "OpenRC user services require XDG_RUNTIME_DIR to be set (e.g. via elogind or shell rc)"
+      else
+        log_info "User mode: unit files created in ~/.config/systemd/user/"
+        log_info "Services are NOT started automatically. Use these commands:"
+        log_info "  Start now:         systemctl --user start clashtui_mihomo"
+        log_info "  Start + autostart: systemctl --user enable --now clashtui_mihomo"
+        log_warn "To keep services running after logout, run: loginctl enable-linger"
+      fi
     fi
   else
     if $IS_MACOS; then

--- a/installs/install
+++ b/installs/install
@@ -569,8 +569,6 @@ After=network.target
 
 [Service]
 Type=simple
-LimitNPROC=500
-LimitNOFILE=1000000
 Restart=always
 ExecStartPre=/usr/bin/sleep 1s
 ExecStart=${INSTALL_DIR_MIHOMO}/mihomo -d ${MIHOMO_CONFIG_DIR}

--- a/installs/install.ps1
+++ b/installs/install.ps1
@@ -179,6 +179,15 @@ function Copy-Contrib {
 }
 
 # --- Backup ---
+function Backup-Dir {
+    param([string]$Path)
+    if (-not (Test-Path $Path)) { return }
+    $i = 1
+    while (Test-Path "${Path}_$i") { $i++ }
+    Copy-Item -Recurse $Path "${Path}_$i"
+    Write-Info "Backed up directory: $Path -> ${Path}_$i"
+}
+
 function Backup-File {
     param([string]$Path)
     if (-not (Test-Path $Path)) { return }
@@ -452,6 +461,7 @@ function New-ClashTuiConfig {
     param([string]$CoreType)
     Write-Info "Creating clashtui config..."
 
+    Backup-Dir $CLASHTUI_CONFIG_DIR
     New-Item -ItemType Directory -Path $CLASHTUI_CONFIG_DIR -Force | Out-Null
 
     # Copy default configs
@@ -461,7 +471,6 @@ function New-ClashTuiConfig {
 
     # Generate config.yaml
     $configPath = Join-Path $CLASHTUI_CONFIG_DIR "config.yaml"
-    Backup-File $configPath
 
     $mihomoBinDir = ($INSTALL_DIR_MIHOMO -replace '\\', '/')
     $singboxBinDir = ($INSTALL_DIR_SINGBOX -replace '\\', '/')
@@ -543,24 +552,28 @@ function New-CoreConfigs {
     Write-Info "Creating core config files..."
 
     if ($CoreType -eq "mihomo" -or $CoreType -eq "all") {
+        Backup-Dir $MIHOMO_CONFIG_DIR
         New-Item -ItemType Directory -Path $MIHOMO_CONFIG_DIR -Force | Out-Null
 
         $cfgSrc = "default_configs/mihomo/core_override_config.yaml"
         Copy-Contrib $cfgSrc (Join-Path $MIHOMO_CONFIG_DIR "config.yaml")
         Write-Info "Mihomo core config written to: $MIHOMO_CONFIG_DIR/config.yaml"
 
+        Backup-Dir $MIHOMO_USER_CONFIG_DIR
         New-Item -ItemType Directory -Path $MIHOMO_USER_CONFIG_DIR -Force | Out-Null
         Copy-Contrib $cfgSrc (Join-Path $MIHOMO_USER_CONFIG_DIR "core_override_config.yaml")
         Write-Info "Mihomo core override written to: $MIHOMO_USER_CONFIG_DIR/core_override_config.yaml"
     }
 
     if ($CoreType -eq "sing-box" -or $CoreType -eq "all") {
+        Backup-Dir $SINGBOX_CONFIG_DIR
         New-Item -ItemType Directory -Path $SINGBOX_CONFIG_DIR -Force | Out-Null
 
         $cfgSrc = "default_configs/sing-box/core_override_config.json"
         Copy-Contrib $cfgSrc (Join-Path $SINGBOX_CONFIG_DIR "config.json")
         Write-Info "Sing-box core config written to: $SINGBOX_CONFIG_DIR/config.json"
 
+        Backup-Dir $SINGBOX_USER_CONFIG_DIR
         New-Item -ItemType Directory -Path $SINGBOX_USER_CONFIG_DIR -Force | Out-Null
         Copy-Contrib $cfgSrc (Join-Path $SINGBOX_USER_CONFIG_DIR "core_override_config.json")
         Write-Info "Sing-box core override written to: $SINGBOX_USER_CONFIG_DIR/core_override_config.json"

--- a/installs/tests/install.bats
+++ b/installs/tests/install.bats
@@ -294,7 +294,7 @@ teardown() {
   [[ "$output" == *"SYSTEMD_RELOAD=NOT_SET"* ]]
 }
 
-@test "resolve_paths with SERVICE_CONTROLLER=openrc and IS_USER=true forces IS_USER=false" {
+@test "resolve_paths with SERVICE_CONTROLLER=openrc and IS_USER=true keeps IS_USER=true" {
   run bash -c "
     source '${PROJECT_ROOT}/installs/install'
     SERVICE_CONTROLLER=openrc
@@ -304,8 +304,8 @@ teardown() {
     echo \"SERVICE_IS_USER=\$SERVICE_IS_USER\"
   "
   [ "$status" -eq 0 ]
-  [[ "$output" == *"IS_USER=false"* ]]
-  [[ "$output" == *"SERVICE_IS_USER=false"* ]]
+  [[ "$output" == *"IS_USER=true"* ]]
+  [[ "$output" == *"SERVICE_IS_USER=true"* ]]
 }
 
 # ---------------------------------------------------------------------------
@@ -334,7 +334,7 @@ teardown() {
   [[ "$output" != *"/usr/lib/systemd/system"* ]]
 }
 
-@test "install --is-test --service-controller openrc --is-user ignores --is-user" {
+@test "install --is-test --service-controller openrc --is-user works in user mode" {
   run bash "${PROJECT_ROOT}/installs/install" \
     --is-test \
     --service-controller openrc \
@@ -345,13 +345,12 @@ teardown() {
 
   [ "$status" -eq 0 ]
 
-  # Should warn about ignoring --is-user
-  [[ "$output" == *"OpenRC does not support user services"* ]]
+  # Should NOT warn about ignoring --is-user (OpenRC supports user services)
+  [[ "$output" != *"does not support user services"* ]]
 
   local test_dir=$(echo "$output" | grep -oP 'Test mode: using temp directory \K.*')
   if [ -n "$test_dir" ]; then
-    # Should use system install path (opt/clashtui), not user path
-    [ -d "$test_dir/opt/clashtui" ]
+    [ -d "$test_dir/config/clashtui" ]
   fi
 }
 

--- a/installs/tests/install.bats
+++ b/installs/tests/install.bats
@@ -275,6 +275,122 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
+# OpenRC support tests: internal state verification
+# ---------------------------------------------------------------------------
+
+@test "resolve_paths with SERVICE_CONTROLLER=openrc sets UNIT_DIR to /etc/init.d" {
+  run bash -c "
+    source '${PROJECT_ROOT}/installs/install'
+    SERVICE_CONTROLLER=openrc
+    IS_USER=false
+    resolve_paths
+    echo \"UNIT_DIR=\$UNIT_DIR\"
+    echo \"SERVICE_IS_USER=\$SERVICE_IS_USER\"
+    echo \"SYSTEMD_RELOAD=\${SYSTEMD_RELOAD:-NOT_SET}\"
+  "
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"UNIT_DIR=/etc/init.d"* ]]
+  [[ "$output" == *"SERVICE_IS_USER=false"* ]]
+  [[ "$output" == *"SYSTEMD_RELOAD=NOT_SET"* ]]
+}
+
+@test "resolve_paths with SERVICE_CONTROLLER=openrc and IS_USER=true forces IS_USER=false" {
+  run bash -c "
+    source '${PROJECT_ROOT}/installs/install'
+    SERVICE_CONTROLLER=openrc
+    IS_USER=true
+    resolve_paths
+    echo \"IS_USER=\$IS_USER\"
+    echo \"SERVICE_IS_USER=\$SERVICE_IS_USER\"
+  "
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"IS_USER=false"* ]]
+  [[ "$output" == *"SERVICE_IS_USER=false"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# OpenRC support tests
+# ---------------------------------------------------------------------------
+
+@test "install --is-test --service-controller openrc creates init script in /etc/init.d" {
+  run bash "${PROJECT_ROOT}/installs/install" \
+    --is-test \
+    --service-controller openrc \
+    --repo "JohanChane/clashtui" \
+    --branch "demotui" \
+    --core mihomo
+
+  [ "$status" -eq 0 ]
+
+  local test_dir=$(echo "$output" | grep -oP 'Test mode: using temp directory \K.*')
+  if [ -n "$test_dir" ]; then
+    [ -d "$test_dir/opt/clashtui/mihomo" ]
+    [ -d "$test_dir/config/clashtui" ]
+  fi
+
+  # Should NOT contain "Creating mihomo systemd unit"
+  [[ "$output" != *"Creating mihomo systemd unit"* ]]
+  # Should NOT contain systemd paths
+  [[ "$output" != *"/usr/lib/systemd/system"* ]]
+}
+
+@test "install --is-test --service-controller openrc --is-user ignores --is-user" {
+  run bash "${PROJECT_ROOT}/installs/install" \
+    --is-test \
+    --service-controller openrc \
+    --is-user \
+    --repo "JohanChane/clashtui" \
+    --branch "demotui" \
+    --core mihomo
+
+  [ "$status" -eq 0 ]
+
+  # Should warn about ignoring --is-user
+  [[ "$output" == *"OpenRC does not support user services"* ]]
+
+  local test_dir=$(echo "$output" | grep -oP 'Test mode: using temp directory \K.*')
+  if [ -n "$test_dir" ]; then
+    # Should use system install path (opt/clashtui), not user path
+    [ -d "$test_dir/opt/clashtui" ]
+  fi
+}
+
+@test "install --is-test --service-controller openrc config.yaml contains service_controller" {
+  run bash "${PROJECT_ROOT}/installs/install" \
+    --is-test \
+    --service-controller openrc \
+    --repo "JohanChane/clashtui" \
+    --branch "demotui" \
+    --core all
+
+  [ "$status" -eq 0 ]
+
+  local test_dir=$(echo "$output" | grep -oP 'Test mode: using temp directory \K.*')
+  if [ -n "$test_dir" ]; then
+    local config_path="$test_dir/config/clashtui/config.yaml"
+    [ -f "$config_path" ]
+    grep -q "service_controller: openrc" "$config_path"
+  fi
+}
+
+@test "install --is-test --service-controller openrc creates init scripts for both services" {
+  run bash "${PROJECT_ROOT}/installs/install" \
+    --is-test \
+    --service-controller openrc \
+    --repo "JohanChane/clashtui" \
+    --branch "demotui" \
+    --core all
+
+  [ "$status" -eq 0 ]
+
+  # Should NOT contain any systemd-specific log messages
+  [[ "$output" != *"Creating mihomo systemd unit"* ]]
+  [[ "$output" != *"Creating sing-box systemd unit"* ]]
+  # Should use system-level paths (not user)
+  [[ "$output" != *"--user"* ]] || true
+}
+
+# ---------------------------------------------------------------------------
 # Test that sourcing does not execute main
 # ---------------------------------------------------------------------------
 

--- a/src/config/core.rs
+++ b/src/config/core.rs
@@ -37,6 +37,10 @@ pub struct CoreServiceConfig {
     /// Controls --user flag (systemd user service) and whether sudo prefix is needed.
     /// When false, `sudo -n true` is used to detect NOPASSWD and skip password prompt.
     pub is_user: bool,
+    /// Init system controller override. Supported values: `"systemd"`, `"openrc"`.
+    /// When absent or unrecognized, the compile-time platform default is used.
+    /// Non-Linux platforms ignore this field.
+    pub service_controller: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
@@ -86,6 +90,7 @@ impl Default for ConfigFile {
                     core_service: CoreServiceConfig {
                         service_name: "clashtui_mihomo".into(),
                         is_user: false,
+                        service_controller: None,
                     },
                 },
                 singbox: SingboxSection {
@@ -97,6 +102,7 @@ impl Default for ConfigFile {
                     core_service: CoreServiceConfig {
                         service_name: "clashtui_singbox".into(),
                         is_user: false,
+                        service_controller: None,
                     },
                 },
                 timeout: Default::default(),
@@ -114,6 +120,7 @@ impl Default for ConfigFile {
                 core_service: CoreServiceConfig {
                     service_name: "clashtui_mihomo".into(),
                     is_user: false,
+                    service_controller: None,
                 },
             },
             singbox: SingboxSection {
@@ -125,6 +132,7 @@ impl Default for ConfigFile {
                 core_service: CoreServiceConfig {
                     service_name: "clashtui_singbox".into(),
                     is_user: false,
+                    service_controller: None,
                 },
             },
             timeout: Default::default(),
@@ -180,6 +188,19 @@ impl Default for ServiceController {
     }
 }
 impl ServiceController {
+    pub fn from_config(csc: &CoreServiceConfig) -> Self {
+        match csc.service_controller.as_deref() {
+            Some("systemd") => ServiceController::Systemd,
+            Some("openrc") if cfg!(not(windows)) && cfg!(not(target_os = "macos")) => {
+                ServiceController::OpenRc
+            }
+            Some(v) => {
+                log::warn!("Unknown service_controller '{v}', falling back to platform default");
+                Self::default()
+            }
+            None => Self::default(),
+        }
+    }
     pub fn args<'a>(
         &self,
         work_type: &'a str,
@@ -189,7 +210,6 @@ impl ServiceController {
         match self {
             ServiceController::Systemd if is_user => vec!["--user", work_type, service_name],
             ServiceController::Systemd => vec![work_type, service_name],
-            ServiceController::OpenRc if is_user => vec![service_name, work_type, "--user"],
             ServiceController::OpenRc => vec![service_name, work_type],
             ServiceController::Nssm => vec![work_type, service_name],
             // Launchd args are constructed inline in svc_operation
@@ -394,7 +414,7 @@ open_dir_cmd: ""
     #[test]
     fn service_controller_args_openrc_user() {
         let args = ServiceController::OpenRc.args("restart", "svc", true);
-        assert_eq!(args, vec!["svc", "restart", "--user"]);
+        assert_eq!(args, vec!["svc", "restart"]);
     }
 
     #[test]
@@ -409,5 +429,107 @@ open_dir_cmd: ""
         assert!(args.is_empty());
         let args = ServiceController::Launchd.args("restart", "svc", true);
         assert!(args.is_empty());
+    }
+
+    // --- Deserialization tests ---
+
+    #[test]
+    fn core_service_config_deser_openrc() {
+        let yaml = "service_name: svc\nis_user: false\nservice_controller: openrc";
+        let csc: CoreServiceConfig = serde_yml::from_str(yaml).unwrap();
+        assert_eq!(csc.service_name, "svc");
+        assert!(!csc.is_user);
+        assert_eq!(csc.service_controller.as_deref(), Some("openrc"));
+    }
+
+    #[test]
+    fn core_service_config_deser_absent() {
+        let yaml = "service_name: svc\nis_user: true";
+        let csc: CoreServiceConfig = serde_yml::from_str(yaml).unwrap();
+        assert_eq!(csc.service_name, "svc");
+        assert!(csc.is_user);
+        assert_eq!(csc.service_controller, None);
+    }
+
+    #[test]
+    fn core_service_config_roundtrip() {
+        let csc = CoreServiceConfig {
+            service_name: "roundtrip_svc".into(),
+            is_user: true,
+            service_controller: Some("openrc".into()),
+        };
+        let yaml = serde_yml::to_string(&csc).unwrap();
+        let deser: CoreServiceConfig = serde_yml::from_str(&yaml).unwrap();
+        assert_eq!(deser.service_name, csc.service_name);
+        assert_eq!(deser.is_user, csc.is_user);
+        assert_eq!(deser.service_controller.as_deref(), Some("openrc"));
+    }
+
+    // --- from_config tests ---
+
+    #[test]
+    fn service_controller_from_config_none_is_default() {
+        let csc = CoreServiceConfig {
+            service_controller: None,
+            ..Default::default()
+        };
+        assert_eq!(ServiceController::from_config(&csc), ServiceController::default());
+    }
+
+    #[test]
+    fn service_controller_from_config_systemd() {
+        let csc = CoreServiceConfig {
+            service_controller: Some("systemd".into()),
+            ..Default::default()
+        };
+        assert_eq!(ServiceController::from_config(&csc), ServiceController::Systemd);
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    #[test]
+    fn service_controller_from_config_openrc_linux() {
+        let csc = CoreServiceConfig {
+            service_controller: Some("openrc".into()),
+            ..Default::default()
+        };
+        assert_eq!(ServiceController::from_config(&csc), ServiceController::OpenRc);
+    }
+
+    #[cfg(any(windows, target_os = "macos"))]
+    #[test]
+    fn service_controller_from_config_openrc_non_linux() {
+        let csc = CoreServiceConfig {
+            service_controller: Some("openrc".into()),
+            ..Default::default()
+        };
+        assert_eq!(ServiceController::from_config(&csc), ServiceController::default());
+    }
+
+    #[test]
+    fn service_controller_from_config_unknown_fallback() {
+        let csc = CoreServiceConfig {
+            service_controller: Some("runit".into()),
+            ..Default::default()
+        };
+        assert_eq!(ServiceController::from_config(&csc), ServiceController::default());
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    #[test]
+    fn service_controller_from_config_openrc_generates_correct_commands() {
+        let csc = CoreServiceConfig {
+            service_name: "clashtui_test".into(),
+            is_user: false,
+            service_controller: Some("openrc".into()),
+        };
+        let ctrl = ServiceController::from_config(&csc);
+        assert_eq!(ctrl, ServiceController::OpenRc);
+        assert_eq!(ctrl.bin_name(), "rc-service");
+        assert_eq!(ctrl.args("start", "clashtui_test", false), vec!["clashtui_test", "start"]);
+        assert_eq!(ctrl.args("stop", "clashtui_test", false), vec!["clashtui_test", "stop"]);
+        assert_eq!(
+            ctrl.args("restart", "clashtui_test", true),
+            vec!["clashtui_test", "restart"]
+        );
     }
 }

--- a/src/config/core.rs
+++ b/src/config/core.rs
@@ -476,7 +476,10 @@ open_dir_cmd: ""
             service_controller: None,
             ..Default::default()
         };
-        assert_eq!(ServiceController::from_config(&csc), ServiceController::default());
+        assert_eq!(
+            ServiceController::from_config(&csc),
+            ServiceController::default()
+        );
     }
 
     #[test]
@@ -485,7 +488,10 @@ open_dir_cmd: ""
             service_controller: Some("systemd".into()),
             ..Default::default()
         };
-        assert_eq!(ServiceController::from_config(&csc), ServiceController::Systemd);
+        assert_eq!(
+            ServiceController::from_config(&csc),
+            ServiceController::Systemd
+        );
     }
 
     #[cfg(all(unix, not(target_os = "macos")))]
@@ -495,7 +501,10 @@ open_dir_cmd: ""
             service_controller: Some("openrc".into()),
             ..Default::default()
         };
-        assert_eq!(ServiceController::from_config(&csc), ServiceController::OpenRc);
+        assert_eq!(
+            ServiceController::from_config(&csc),
+            ServiceController::OpenRc
+        );
     }
 
     #[cfg(any(windows, target_os = "macos"))]
@@ -505,7 +514,10 @@ open_dir_cmd: ""
             service_controller: Some("openrc".into()),
             ..Default::default()
         };
-        assert_eq!(ServiceController::from_config(&csc), ServiceController::default());
+        assert_eq!(
+            ServiceController::from_config(&csc),
+            ServiceController::default()
+        );
     }
 
     #[test]
@@ -514,7 +526,10 @@ open_dir_cmd: ""
             service_controller: Some("runit".into()),
             ..Default::default()
         };
-        assert_eq!(ServiceController::from_config(&csc), ServiceController::default());
+        assert_eq!(
+            ServiceController::from_config(&csc),
+            ServiceController::default()
+        );
     }
 
     #[cfg(all(unix, not(target_os = "macos")))]
@@ -528,8 +543,14 @@ open_dir_cmd: ""
         let ctrl = ServiceController::from_config(&csc);
         assert_eq!(ctrl, ServiceController::OpenRc);
         assert_eq!(ctrl.bin_name(), "rc-service");
-        assert_eq!(ctrl.args("start", "clashtui_test", false), vec!["clashtui_test", "start"]);
-        assert_eq!(ctrl.args("stop", "clashtui_test", false), vec!["clashtui_test", "stop"]);
+        assert_eq!(
+            ctrl.args("start", "clashtui_test", false),
+            vec!["clashtui_test", "start"]
+        );
+        assert_eq!(
+            ctrl.args("stop", "clashtui_test", false),
+            vec!["clashtui_test", "stop"]
+        );
         assert_eq!(
             ctrl.args("restart", "clashtui_test", true),
             vec!["--user", "clashtui_test", "restart"]

--- a/src/config/core.rs
+++ b/src/config/core.rs
@@ -210,6 +210,9 @@ impl ServiceController {
         match self {
             ServiceController::Systemd if is_user => vec!["--user", work_type, service_name],
             ServiceController::Systemd => vec![work_type, service_name],
+            ServiceController::OpenRc if is_user => {
+                vec!["--user", service_name, work_type]
+            }
             ServiceController::OpenRc => vec![service_name, work_type],
             ServiceController::Nssm => vec![work_type, service_name],
             // Launchd args are constructed inline in svc_operation
@@ -414,7 +417,7 @@ open_dir_cmd: ""
     #[test]
     fn service_controller_args_openrc_user() {
         let args = ServiceController::OpenRc.args("restart", "svc", true);
-        assert_eq!(args, vec!["svc", "restart"]);
+        assert_eq!(args, vec!["--user", "svc", "restart"]);
     }
 
     #[test]
@@ -529,7 +532,7 @@ open_dir_cmd: ""
         assert_eq!(ctrl.args("stop", "clashtui_test", false), vec!["clashtui_test", "stop"]);
         assert_eq!(
             ctrl.args("restart", "clashtui_test", true),
-            vec!["clashtui_test", "restart"]
+            vec!["--user", "clashtui_test", "restart"]
         );
     }
 }

--- a/src/functions/command.rs
+++ b/src/functions/command.rs
@@ -124,18 +124,20 @@ pub fn check_config(profile_path: &Path) -> anyhow::Result<()> {
 }
 
 pub fn is_core_service_running() -> Option<bool> {
-    let host = &ServiceController::default();
     let ct = CONFIG.core_type();
-    let (service_name, is_user) = match ct {
+    let (service_name, is_user, csc) = match ct {
         CoreType::Mihomo => (
             &CONFIG.cfg_file.mihomo.core_service.service_name,
             CONFIG.cfg_file.mihomo.core_service.is_user,
+            &CONFIG.cfg_file.mihomo.core_service,
         ),
         CoreType::Singbox => (
             &CONFIG.cfg_file.singbox.core_service.service_name,
             CONFIG.cfg_file.singbox.core_service.is_user,
+            &CONFIG.cfg_file.singbox.core_service,
         ),
     };
+    let host = &ServiceController::from_config(csc);
 
     if service_name.is_empty() {
         return None;
@@ -147,7 +149,15 @@ pub fn is_core_service_running() -> Option<bool> {
         return Some(s == "active");
     }
 
-    if matches!(host, ServiceController::Systemd | ServiceController::OpenRc) {
+    if matches!(host, ServiceController::OpenRc) {
+        return std::process::Command::new(host.bin_name())
+            .args([service_name.as_str(), "status"])
+            .output()
+            .map(|o| Some(String::from_utf8_lossy(&o.stdout).contains("started")))
+            .unwrap_or(None);
+    }
+
+    if matches!(host, ServiceController::Systemd) {
         let mut args = vec!["is-active"];
         if is_user {
             args.push("--user");
@@ -174,19 +184,21 @@ pub fn is_core_service_running() -> Option<bool> {
 }
 
 fn svc_operation(op: &str, password: Option<&str>, core_type: Option<CoreType>) -> Result<String> {
-    let host = &ServiceController::default();
     let ct = core_type.unwrap_or(CONFIG.core_type());
 
-    let (service_name, is_user) = match ct {
+    let (service_name, is_user, csc) = match ct {
         CoreType::Mihomo => (
             &CONFIG.cfg_file.mihomo.core_service.service_name,
             CONFIG.cfg_file.mihomo.core_service.is_user,
+            &CONFIG.cfg_file.mihomo.core_service,
         ),
         CoreType::Singbox => (
             &CONFIG.cfg_file.singbox.core_service.service_name,
             CONFIG.cfg_file.singbox.core_service.is_user,
+            &CONFIG.cfg_file.singbox.core_service,
         ),
     };
+    let host = &ServiceController::from_config(csc);
 
     if matches!(host, ServiceController::Launchd) {
         return launchd_operation(op, service_name, is_user, password);

--- a/src/functions/command.rs
+++ b/src/functions/command.rs
@@ -150,8 +150,14 @@ pub fn is_core_service_running() -> Option<bool> {
     }
 
     if matches!(host, ServiceController::OpenRc) {
+        let mut args = vec![];
+        if is_user {
+            args.push("--user");
+        }
+        args.push(service_name.as_str());
+        args.push("status");
         return std::process::Command::new(host.bin_name())
-            .args([service_name.as_str(), "status"])
+            .args(&args)
             .output()
             .map(|o| Some(String::from_utf8_lossy(&o.stdout).contains("started")))
             .unwrap_or(None);

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -84,6 +84,9 @@ impl App {
     }
     #[cfg(target_family = "unix")]
     fn check_startup_perms(&self) {
+        if crate::config::CONFIG.cfg_file.mihomo.core_service.is_user {
+            return;
+        }
         use std::io::Write;
 
         let dirs_to_check = [

--- a/src/tui/tab/proxies/content.rs
+++ b/src/tui/tab/proxies/content.rs
@@ -95,10 +95,7 @@ impl Proxies {
                 }
             }
             super::Key::Parent => {
-                let info = self
-                    .tree
-                    .node_at(current)
-                    .map(|n| n.parent.clone());
+                let info = self.tree.node_at(current).map(|n| n.parent.clone());
                 if let Some(Some(ref parent)) = info {
                     if let Some(idx) = self.tree.find_folder_index(parent) {
                         state.select(Some(idx));

--- a/src/tui/tab/srvctl.rs
+++ b/src/tui/tab/srvctl.rs
@@ -124,17 +124,43 @@ struct SrvCtlContent {
 
 impl SrvCtlContent {
     fn spawn_status_check(&self, task_set: &mut FutureSet<Self>, target: CoreType) {
-        let (service_name, is_user) = match target {
-            CoreType::Mihomo => (self.mihomo_service_name.clone(), self.mihomo_is_user),
-            CoreType::Singbox => (self.singbox_service_name.clone(), self.singbox_is_user),
+        let (service_name, is_user, csc) = match target {
+            CoreType::Mihomo => (
+                self.mihomo_service_name.clone(),
+                self.mihomo_is_user,
+                crate::config::CONFIG.cfg_file.mihomo.core_service.clone(),
+            ),
+            CoreType::Singbox => (
+                self.singbox_service_name.clone(),
+                self.singbox_is_user,
+                crate::config::CONFIG.cfg_file.singbox.core_service.clone(),
+            ),
         };
-        let controller = crate::config::ServiceController::default();
+        let controller = crate::config::ServiceController::from_config(&csc);
         async move {
             let status = match controller {
                 crate::config::ServiceController::Launchd => launchd_status(&service_name, is_user),
                 #[cfg(windows)]
                 crate::config::ServiceController::Nssm => {
                     crate::functions::command::nssm_status(&service_name)
+                }
+                crate::config::ServiceController::OpenRc => {
+                    let mut args = vec![service_name.as_str(), "status"];
+                    let bin = controller.bin_name();
+                    let output = std::process::Command::new(bin).args(&args).output();
+                    match output {
+                        Ok(o) => {
+                            let stdout = String::from_utf8_lossy(&o.stdout);
+                            if stdout.contains("started") {
+                                "active".to_owned()
+                            } else if stdout.contains("stopped") {
+                                "inactive".to_owned()
+                            } else {
+                                stdout.trim().to_owned()
+                            }
+                        }
+                        Err(_) => "?".to_owned(),
+                    }
                 }
                 _ => {
                     let mut args = vec!["is-active"];
@@ -159,13 +185,35 @@ impl SrvCtlContent {
     fn spawn_current_status_check(&self, task_set: &mut FutureSet<Self>) {
         let service_name = self.service_name.clone();
         let is_user = self.is_user;
-        let controller = crate::config::ServiceController::default();
+        let csc = match crate::config::CONFIG.core_type() {
+            CoreType::Mihomo => crate::config::CONFIG.cfg_file.mihomo.core_service.clone(),
+            CoreType::Singbox => crate::config::CONFIG.cfg_file.singbox.core_service.clone(),
+        };
+        let controller = crate::config::ServiceController::from_config(&csc);
         async move {
             let status = match controller {
                 crate::config::ServiceController::Launchd => launchd_status(&service_name, is_user),
                 #[cfg(windows)]
                 crate::config::ServiceController::Nssm => {
                     crate::functions::command::nssm_status(&service_name)
+                }
+                crate::config::ServiceController::OpenRc => {
+                    let mut args = vec![service_name.as_str(), "status"];
+                    let bin = controller.bin_name();
+                    let output = std::process::Command::new(bin).args(&args).output();
+                    match output {
+                        Ok(o) => {
+                            let stdout = String::from_utf8_lossy(&o.stdout);
+                            if stdout.contains("started") {
+                                "active".to_owned()
+                            } else if stdout.contains("stopped") {
+                                "inactive".to_owned()
+                            } else {
+                                stdout.trim().to_owned()
+                            }
+                        }
+                        Err(_) => "?".to_owned(),
+                    }
                 }
                 _ => {
                     let mut args = vec!["is-active"];


### PR DESCRIPTION
## Summary

This PR adds OpenRC service controller support for Linux platforms (Gentoo, Alpine, etc.), alongside the existing systemd controller. It also improves CI caching, enhances the install script, and adds comprehensive manual installation guides.

## Changes

### OpenRC Service Controller (`src/config/core.rs`, `src/functions/command.rs`, `src/tui/tab/srvctl.rs`)

- Added `service_controller` field to `core_service` config sections (`"systemd"` or `"openrc"`)
- Implemented OpenRC command mapping: `rc-service` for start/stop/restart/status, `rc-update` for enable/disable
- User mode support via `--user` flag (OpenRC v0.60+, init scripts in `/etc/user/init.d/`)
- System mode uses `sudo rc-service`, user mode uses `rc-service --user`
- Status checking properly handles `--user` flag for user mode
- Added OpenRC runtime behavior documentation to feature design docs (EN/ZH)

### Install Script (`installs/install`, `installs/install.ps1`)

- New `--service-controller` argument to select between systemd and openrc
- Generates proper OpenRC init scripts with `supervise-daemon` for foreground process management
- System mode: scripts in `/etc/init.d/`, includes `command_user` for service user
- User mode: scripts in `/etc/user/init.d/`, runs as current user
- Uninstall correctly handles OpenRC mode (system and user)
- Backup now preserves the entire config directory instead of individual files
- Removed `LimitNPROC` from mihomo service definition

### CI/CD (`.github/workflows/*.yml`)

- Cache only `~/.cargo` registry, not `./target` build artifacts
- Unified cache key format across all workflows
- Added `--locked` flag to `cargo test` commands

### Manual Installation Docs

- Added `docs/install_manually_en.md` — step-by-step guide for both system and user mode
- Added `docs/install_manually_zh.md` — Chinese version
- Linked from `README.md` and `README_ZH.md`

### Misc

- Skip permission check and repair when running in user mode
- Fixed README_ZH.md contributor links
- `cargo fmt`

## Tested

- [x] `cargo test --all --all-features` passes
- [x] Install script tested on Linux with systemd and openrc
- [x] Install bats tests updated for OpenRC user mode