### PR TITLE
fix: resolve three Windows cmd string generation issues and support irm|iex remote install

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,13 +115,13 @@ This step ensures mihomo, sing-box, and clashtui are in PATH so the install scri
 
 ```powershell
 # Default install to D:\ClashTui
-.\installs\install.ps1 --core all
+irm https://raw.githubusercontent.com/JohanChane/clashtui/refs/heads/main/installs/install.ps1 | iex
 
 # Custom directory (no spaces allowed)
-.\installs\install.ps1 --core all -InstallDir "D:\MyTools\ClashTui"
+iex "& {$(irm https://raw.githubusercontent.com/JohanChane/clashtui/refs/heads/main/installs/install.ps1)} -Core all -InstallDir 'D:\MyTools\ClashTui'"
 
 # Only install mihomo core
-.\installs\install.ps1 --core mihomo
+iex "& {$(irm https://raw.githubusercontent.com/JohanChane/clashtui/refs/heads/main/installs/install.ps1)} -Core mihomo"
 ```
 
 3. Start clashtui, then use CoreSrvCtl to install and start core services:

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -110,13 +110,13 @@ Get-Command mihomo sing-box clashtui
 
 ```powershell
 # 默认安装到 D:\ClashTui
-.\installs\install.ps1 --core all
+irm https://raw.githubusercontent.com/JohanChane/clashtui/refs/heads/main/installs/install.ps1 | iex
 
 # 安装到自定义目录 (路径不能有空格)
-.\installs\install.ps1 --core all -InstallDir "D:\MyTools\ClashTui"
+iex "& {$(irm https://raw.githubusercontent.com/JohanChane/clashtui/refs/heads/main/installs/install.ps1)} -Core all -InstallDir 'D:\MyTools\ClashTui'"
 
 # 只安装 mihomo core
-.\installs\install.ps1 --core mihomo
+iex "& {$(irm https://raw.githubusercontent.com/JohanChane/clashtui/refs/heads/main/installs/install.ps1)} -Core mihomo"
 ```
 
 3. 启动 clashtui 安装 clashtui_mihomo/clashtui_singbox 服务

--- a/docs/clashtui_feature_design_en.md
+++ b/docs/clashtui_feature_design_en.md
@@ -1338,3 +1338,58 @@ depend() {
 `install --uninstall` correctly handles openrc mode:
 - System mode: runs `sudo rc-update del`, `sudo rc-service stop`, removes scripts from `/etc/init.d/`
 - User mode: runs `rc-update --user del`, `rc-service --user stop`, removes scripts from `/etc/user/init.d/`
+
+## Windows Cmd String Generation: Problems and Solutions (Three Major Issues)
+
+### 1. `canonicalize()` Injects `\\?\` Prefix
+
+`init()` calls `canonicalize()` on `DATA_DIR`, which on Windows prepends `\\?\` (verbatim path) to the path. All derived paths (`core_data_dir`, profile path, etc.) inherit this prefix. Neither explorer nor cmd recognize the `\\?\` format.
+
+**Log evidence:**
+```
+core_data_dir=\\?\C:\Users\johan\AppData\Roaming\clashtui\mihomo
+```
+
+**Fix:** After `canonicalize()`, use [dunce](https://lib.rs/crates/dunce) to obtain a path that applications can work with.
+
+References:
+- [std::fs::canonicalize returns UNC paths on Windows, and a lot of software doesn't support UNC paths](https://github.com/rust-lang/rust/issues/42869)
+
+### 2. Rust `Command::args` Double-Escapes Arguments Containing Quotes
+
+After substituting `%s` in the template, a complete command string with embedded quotes is produced (e.g., `start "" "C:\..."`) and passed as a single argument to `Command::args`. Rust re-escapes arguments containing quotes when constructing the `CreateProcessW` command line, causing `cmd /c` to parse an incorrect command.
+
+**Correct way** (separate args):
+```rust
+spawn("cmd", vec!["/c", "start", "", path])
+```
+
+**Problematic way** (embedded quotes in arg):
+```rust
+spawn("cmd", vec!["/c", "start \"\" \"C:\\path\""])
+```
+
+**Fix:** Use `raw_arg` to bypass Rust's re-escaping and pass the command string verbatim to `CreateProcessW`:
+```rust
+use std::os::windows::process::CommandExt;
+let safe_path = path.replace('\\', "/");
+let replaced = template.replace("%s", &safe_path);
+Command::new("cmd")
+    .raw_arg("/c")
+    .raw_arg(replaced)   // verbatim, no re-escaping
+    .spawn()?;
+```
+
+**Why this wasn't triggered before:** The HEAD version's empty-string fallback uses separate args, which is correct. However, `Default for Extra` returned non-empty templates that took the path concatenation path, which has the same bug — users were simply either blocked by bug #1 or had custom commands configured that avoided it.
+
+### 3. `explorer.exe` Exit Code 1
+
+Calling `explorer.exe` from a child process as `explorer "path"` returns exit code 1 (failure). On Windows, the correct approach is `cmd /c start "" "path"` (which goes through ShellExecute).
+
+### Windows Path Solution Summary
+
+Since the only operation is substituting `%s` with a path, the focus is on ensuring the path doesn't break within the command string. This type of issue is mostly Windows-specific; Unix-like systems generally don't have these problems. The Windows path issues can be solved as follows:
+- When a Windows path appears in a command-line string, use `C:/Users/Foo` format instead of `C:\\Users\\Foo` to avoid escaping issues.
+- For the `canonicalize()` UNC paths issue, convert UNC paths to cmd-compatible paths only when passing them to cmd (many applications don't support UNC paths).
+- Do not run `explorer "path"`; use `cmd /c start "" "path"` instead.
+- To prevent `Command::args` from double-escaping quoted arguments, use `raw_arg`.

--- a/docs/clashtui_feature_design_zh.md
+++ b/docs/clashtui_feature_design_zh.md
@@ -1227,3 +1227,57 @@ depend() {
 - System 模式: 执行 `sudo rc-update del` 和 `sudo rc-service stop`, 删除 `/etc/init.d/` 下的脚本
 - User 模式: 执行 `rc-update --user del` 和 `rc-service --user stop`, 删除 `/etc/user/init.d/` 下的脚本
 
+## Windows cmd 字符串的生成的问题分析与解决方案 (三个主要的问题)
+
+### 1. `canonicalize()` 注入 `\\?\` 前缀
+
+`init()` 中对 `DATA_DIR` 调用了 `canonicalize()`，Windows 上会给路径加上 `\\?\` 前缀（verbatim path）。所有派生路径（`core_data_dir`、profile path 等）全部继承此前缀。explorer / cmd 不认 `\\?\` 格式。
+
+**日志证据：**
+```
+core_data_dir=\\?\C:\Users\johan\AppData\Roaming\clashtui\mihomo
+```
+
+**解决：** `canonicalize()` 后使用 [dunce](https://lib.rs/crates/dunce) 取得 app 支持的 path。
+
+References:
+-   [std::fs::canonicalize returns UNC paths on Windows, and a lot of software doesn't support UNC paths](https://github.com/rust-lang/rust/issues/42869)
+
+### 2. Rust `Command::args` 对含引号参数的二次转义
+
+模板经 `%s` 替换后拼出一个含引号的完整命令字符串（如 `start "" "C:\..."`），作为单个参数传给 `Command::args`。Rust 在构造 `CreateProcessW` 命令行时会对含引号的参数再次转义，导致 `cmd /c` 解析出的实际命令错误。
+
+**正确的参数传递方式**（arg 分开传）：
+```rust
+spawn("cmd", vec!["/c", "start", "", path])
+```
+
+**有问题的做法**（arg 内嵌引号）：
+```rust
+spawn("cmd", vec!["/c", "start \"\" \"C:\\path\""])
+```
+
+**解决方法：** 使用 `raw_arg` 绕过 Rust 的二次转义，将命令字符串原样传给 `CreateProcessW`：
+```rust
+use std::os::windows::process::CommandExt;
+let safe_path = path.replace('\\', "/");
+let replaced = template.replace("%s", &safe_path);
+Command::new("cmd")
+    .raw_arg("/c")
+    .raw_arg(replaced)   // 原样，不二次转义
+    .spawn()?;
+```
+
+**之前为什么没触发：** HEAD 版本里空字符串 fallback 用的是 arg 分开传的方式，没问题。但 `Default for Extra` 返回的非空模板走的是拼接路径，同样存在这个 bug——只是用户要么被 bug#1 挡住了，要么配了自定义命令绕过了。
+
+### 3. `explorer.exe` 退出码 1
+
+从子进程以 `explorer "path"` 形式调用 explorer.exe 返回退出码 1（失败）。Windows 上正确做法是用 `cmd /c start "" "path"`（走 ShellExecute）。
+
+### Windows 路径问题的解决方案
+
+因为只是 `%s` 替换为 path, 我觉得只需解决 path 在命令字符串中不出错即可。而且这种问题一般只会出现在 Windows, Unix Like 基本不会有这样的问题。所以 Windows path 只需要解决以下问题即可:
+-   Windows path, 在命令行字符串中时, 使用 `C:/Users/Foo` 的格式, 不要使用 `C:\\Users\\Foo`, 防止转义的问题。
+-   对于 canonicalize 的 UNC paths 问题, 只要将 path 传给 cmd 命令时, 才将 UNC paths 转换为 cmd 命令支持的 path (很多 app 不支持 UNC paths)
+-   不要以 `explorer "path"` 运行命令, 要以 `cmd /c start "" "path"` 的方式运行命令
+-   为防止 Command::args 对引号参数的二次转义, 使用 raw_arg

--- a/installs/install.ps1
+++ b/installs/install.ps1
@@ -136,7 +136,7 @@ function Resolve-Paths {
         Write-Info "Test mode: using temp directory $TestTmpDir"
     }
 
-    $script:SCRIPT_DIR = Split-Path $MyInvocation.ScriptName -Parent
+    $script:SCRIPT_DIR = if ($MyInvocation.ScriptName) { Split-Path $MyInvocation.ScriptName -Parent } else { Get-Location }
     $contribLocal = Join-Path $SCRIPT_DIR "contrib"
     $contribParent = Join-Path (Split-Path $SCRIPT_DIR -Parent) "contrib"
     if (Test-Path $contribLocal) {

--- a/installs/tests/install.tests.ps1
+++ b/installs/tests/install.tests.ps1
@@ -136,3 +136,38 @@ Describe "Guard: dot-sourcing does not execute Main" {
         { Get-Command Copy-Contrib -ErrorAction Stop } | Should -Not -Throw
     }
 }
+
+Describe "irm|iex remote execution (ScriptName null)" {
+    It "SCRIPT_DIR expression uses fallback when ScriptName is null" {
+        $nullResult = if ($null) { Split-Path $null -Parent } else { (Get-Location).Path }
+        $nullResult | Should -Not -BeNullOrEmpty
+        $nullResult | Should -Be (Get-Location).Path
+    }
+
+    It "SCRIPT_DIR expression uses ScriptName when available" {
+        $validResult = if ($installScript) { Split-Path $installScript -Parent } else { (Get-Location).Path }
+        $validResult | Should -Not -BeNullOrEmpty
+        $validResult | Should -Be (Split-Path $installScript -Parent)
+    }
+
+    It "SCRIPT_DIR falls back to Get-Location when ScriptName is empty" {
+        $sb = [scriptblock]::Create(@"
+`$script:SCRIPT_DIR = if (`$MyInvocation.ScriptName) { Split-Path `$MyInvocation.ScriptName -Parent } else { (Get-Location).Path }
+`$script:SCRIPT_DIR
+"@)
+        $result = & $sb
+        $result | Should -Not -BeNullOrEmpty
+        $result | Should -BeLike "*[\\/]*"
+    }
+
+    It "Full script runs without error when invoked via scriptblock (irm|iex simulation)" {
+        $content = Get-Content -Path $installScript -Raw
+        $sb = [scriptblock]::Create($content)
+        $testDir = Join-Path $env:TEMP "clashtui-iex-full-$(Get-Random)"
+        try {
+            { & $sb -IsTest -InstallDir $testDir -Core mihomo -ErrorAction Stop } | Should -Not -Throw
+        } finally {
+            Remove-Item $testDir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}

--- a/src/config/core.rs
+++ b/src/config/core.rs
@@ -144,27 +144,14 @@ impl Default for ConfigFile {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct Extra {
-    pub edit_cmd: String,
-    pub open_dir_cmd: String,
+    pub edit_cmd: Option<String>,
+    pub open_dir_cmd: Option<String>,
 }
 impl Default for Extra {
     fn default() -> Self {
-        if cfg!(windows) {
-            Self {
-                edit_cmd: r#"notepad.exe "%s""#.to_owned(),
-                open_dir_cmd: r#"explorer "%s""#.to_owned(),
-            }
-        } else if cfg!(target_os = "macos") {
-            Self {
-                edit_cmd: r#"open -t "%s""#.to_owned(),
-                open_dir_cmd: r#"open "%s""#.to_owned(),
-            }
-        } else {
-            let cmd = r#"xdg-open "%s""#.to_owned();
-            Self {
-                edit_cmd: cmd.clone(),
-                open_dir_cmd: cmd,
-            }
+        Self {
+            edit_cmd: None,
+            open_dir_cmd: None,
         }
     }
 }
@@ -310,7 +297,11 @@ extra:
         );
         assert_eq!(cfg.singbox.core_service.service_name, "clashtui_singbox");
         assert_eq!(cfg.timeout, Some(5));
-        assert_eq!(cfg.extra.edit_cmd, r#"kitty -e nvim "%s""#);
+        assert_eq!(cfg.extra.edit_cmd.as_deref(), Some(r#"kitty -e nvim "%s""#));
+        assert_eq!(
+            cfg.extra.open_dir_cmd.as_deref(),
+            Some(r#"kitty -e yazi "%s""#)
+        );
 
         let serialized = serde_yml::to_string(&cfg).unwrap();
         let deser: ConfigFile = serde_yml::from_str(&serialized).unwrap();
@@ -345,28 +336,11 @@ profiles:
         assert_eq!(data.profiles.get("pf2").unwrap().no_pp, false);
     }
 
-    #[cfg(target_os = "macos")]
     #[test]
-    fn extra_default_macos() {
+    fn extra_default_is_none() {
         let extra = Extra::default();
-        assert_eq!(extra.edit_cmd, r#"open -t "%s""#);
-        assert_eq!(extra.open_dir_cmd, r#"open "%s""#);
-    }
-
-    #[cfg(windows)]
-    #[test]
-    fn extra_default_windows() {
-        let extra = Extra::default();
-        assert_eq!(extra.edit_cmd, r#"notepad.exe "%s""#);
-        assert_eq!(extra.open_dir_cmd, r#"explorer "%s""#);
-    }
-
-    #[cfg(all(unix, not(target_os = "macos")))]
-    #[test]
-    fn extra_default_linux() {
-        let extra = Extra::default();
-        assert_eq!(extra.edit_cmd, r#"xdg-open "%s""#);
-        assert_eq!(extra.open_dir_cmd, r#"xdg-open "%s""#);
+        assert_eq!(extra.edit_cmd, None);
+        assert_eq!(extra.open_dir_cmd, None);
     }
 
     #[test]
@@ -378,8 +352,8 @@ edit_cmd: ""
 open_dir_cmd: ""
 "#;
         let extra: Extra = serde_yml::from_str(yaml).unwrap();
-        assert_eq!(extra.edit_cmd, "");
-        assert_eq!(extra.open_dir_cmd, "");
+        assert_eq!(extra.edit_cmd.as_deref(), Some(""));
+        assert_eq!(extra.open_dir_cmd.as_deref(), Some(""));
     }
 
     #[test]

--- a/src/config/core.rs
+++ b/src/config/core.rs
@@ -357,6 +357,38 @@ open_dir_cmd: ""
     }
 
     #[test]
+    fn extra_missing_fields_deserialize_to_none() {
+        let yaml = "{}";
+        let extra: Extra = serde_yml::from_str(yaml).unwrap();
+        assert_eq!(extra.edit_cmd, None);
+        assert_eq!(extra.open_dir_cmd, None);
+    }
+
+    #[test]
+    fn extra_serde_roundtrip_with_none() {
+        let extra = Extra {
+            edit_cmd: None,
+            open_dir_cmd: None,
+        };
+        let serialized = serde_yml::to_string(&extra).unwrap();
+        let deser: Extra = serde_yml::from_str(&serialized).unwrap();
+        assert_eq!(deser.edit_cmd, None);
+        assert_eq!(deser.open_dir_cmd, None);
+    }
+
+    #[test]
+    fn extra_serde_roundtrip_with_some() {
+        let extra = Extra {
+            edit_cmd: Some(r#"notepad.exe "%s""#.into()),
+            open_dir_cmd: Some(r#"explorer "%s""#.into()),
+        };
+        let serialized = serde_yml::to_string(&extra).unwrap();
+        let deser: Extra = serde_yml::from_str(&serialized).unwrap();
+        assert_eq!(deser.edit_cmd.as_deref(), Some(r#"notepad.exe "%s""#));
+        assert_eq!(deser.open_dir_cmd.as_deref(), Some(r#"explorer "%s""#));
+    }
+
+    #[test]
     fn service_controller_bin_name() {
         assert_eq!(ServiceController::Launchd.bin_name(), "launchctl");
         assert_eq!(ServiceController::Systemd.bin_name(), "systemctl");

--- a/src/config/v0_3_0.rs
+++ b/src/config/v0_3_0.rs
@@ -46,8 +46,8 @@ pub fn migrate() -> anyhow::Result<()> {
         singbox: super::core::SingboxSection::default(),
         timeout,
         extra: super::core::Extra {
-            edit_cmd,
-            open_dir_cmd,
+            edit_cmd: (!edit_cmd.is_empty()).then_some(edit_cmd),
+            open_dir_cmd: (!open_dir_cmd.is_empty()).then_some(open_dir_cmd),
         },
     };
 

--- a/src/functions/command.rs
+++ b/src/functions/command.rs
@@ -353,13 +353,13 @@ pub fn stop_all_services(password: Option<&str>) -> Result<String> {
 }
 
 pub fn edit(path: &str) -> Result<()> {
-    let tpl = &CONFIG.cfg_file.extra.edit_cmd;
+    let tpl = CONFIG.cfg_file.extra.edit_cmd.as_deref().unwrap_or("");
     log::debug!("edit: path={path} template={tpl}");
     shell_spawn(tpl, path)
 }
 
 pub fn open_dir(path: &str) -> Result<()> {
-    let tpl = &CONFIG.cfg_file.extra.open_dir_cmd;
+    let tpl = CONFIG.cfg_file.extra.open_dir_cmd.as_deref().unwrap_or("");
     log::debug!("open_dir: path={path} template={tpl}");
     shell_spawn(tpl, path)
 }

--- a/src/functions/command/utils.rs
+++ b/src/functions/command/utils.rs
@@ -40,7 +40,6 @@ pub fn sudo_needs_password() -> bool {
 
 pub fn spawn(pgm: &str, args: Vec<&str>) -> Result<()> {
     log::debug!("SPW: {} {:?}", pgm, args);
-    // Just ignore the output, otherwise the ui might be broken
     Command::new(pgm)
         .stderr(Stdio::null())
         .stdout(Stdio::null())
@@ -49,21 +48,100 @@ pub fn spawn(pgm: &str, args: Vec<&str>) -> Result<()> {
     Ok(())
 }
 
+fn sanitize_windows_path(path: &str) -> String {
+    let path = path
+        .strip_prefix(r"\\?\")
+        .unwrap_or(path);
+    path.replace('\\', "/")
+}
+
 pub fn shell_spawn(cmd_template: &str, path: &str) -> Result<()> {
     if cmd_template.is_empty() {
         if cfg!(windows) {
-            spawn("cmd", vec!["/c", "start", "", path])
+            let path = sanitize_windows_path(path);
+            spawn("cmd", vec!["/c", "start", "", &path])
         } else if cfg!(target_os = "macos") {
             spawn("sh", vec!["-c", &format!("open \"{}\"", path)])
         } else {
             spawn("sh", vec!["-c", &format!("xdg-open \"{}\"", path)])
         }
     } else {
-        let cmd = cmd_template.replace("%s", path);
         if cfg!(windows) {
-            spawn("cmd", vec!["/c", &cmd])
+            let path = sanitize_windows_path(path);
+            let cmd = cmd_template.replace("%s", &path);
+            log::debug!("SPW: cmd {} {}", "cmd", cmd);
+            #[cfg(windows)]
+            {
+                use std::os::windows::process::CommandExt;
+                Command::new("cmd")
+                    .stderr(Stdio::null())
+                    .stdout(Stdio::null())
+                    .raw_arg("/c")
+                    .raw_arg(&cmd)
+                    .spawn()?;
+            }
+            Ok(())
         } else {
+            let cmd = cmd_template.replace("%s", path);
             spawn("sh", vec!["-c", &cmd])
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_unc_prefix_stripped() {
+        assert_eq!(
+            sanitize_windows_path(r"\\?\C:\Users\foo"),
+            "C:/Users/foo"
+        );
+    }
+
+    #[test]
+    fn sanitize_non_unc_untouched() {
+        assert_eq!(
+            sanitize_windows_path(r"C:\Users\foo"),
+            "C:/Users/foo"
+        );
+    }
+
+    #[test]
+    fn sanitize_forward_slashes_unchanged() {
+        assert_eq!(
+            sanitize_windows_path("C:/Users/foo"),
+            "C:/Users/foo"
+        );
+    }
+
+    #[test]
+    fn sanitize_mixed_slashes_converted() {
+        assert_eq!(
+            sanitize_windows_path(r"C:\foo/bar\baz"),
+            "C:/foo/bar/baz"
+        );
+    }
+
+    #[test]
+    fn sanitize_unc_with_mixed_slashes() {
+        assert_eq!(
+            sanitize_windows_path(r"\\?\C:\foo/bar\baz"),
+            "C:/foo/bar/baz"
+        );
+    }
+
+    #[test]
+    fn sanitize_empty_string() {
+        assert_eq!(sanitize_windows_path(""), "");
+    }
+
+    #[test]
+    fn sanitize_path_without_backslashes() {
+        assert_eq!(
+            sanitize_windows_path("C:/foo/bar/baz"),
+            "C:/foo/bar/baz"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes three critical Windows command generation bugs that prevented `edit` and `open_dir` actions from working correctly, and enables `irm | iex` remote installation.

## Changes

### 1. Strip `\\?\` UNC prefix from canonicalized paths (`sanitize_windows_path`)

`canonicalize()` on Windows prepends `\\?\` (verbatim path prefix) to all paths. explorer.exe and cmd.exe do not recognize this format. Added `sanitize_windows_path()` to strip the prefix and convert backslashes to forward slashes before passing paths to shell commands.

### 2. Use `raw_arg` to prevent double-escaping

When a template like `notepad.exe "%s"` is substituted and passed as a single argument to `Command::args`, Rust re-escapes the embedded quotes before constructing the `CreateProcessW` command line, resulting in a broken command. Switched to `raw_arg` on Windows to bypass Rust's re-escaping.

### 3. Replace `explorer.exe` with `cmd /c start`

Running `explorer "path"` from a child process returns exit code 1 (error). Switched to `cmd /c start "" "path"` which correctly delegates to ShellExecute.

### 4. Make `edit_cmd` / `open_dir_cmd` optional (`Option<String>`)

Changed from `String` to `Option<String>` with `None` as default. When `None`, the built-in fallback is used. This fixes the previous issue where non-empty defaults on Windows would trigger the double-escaping bug.

### 5. Support `irm | iex` remote installation

- `install.ps1`: handle `$MyInvocation.ScriptName` being `$null` when invoked via `irm | iex`, falling back to `Get-Location`
- Updated README / README_ZH with `irm | iex` installation examples

### 6. Design documentation

Added comprehensive design docs (`clashtui_feature_design_en.md` / `clashtui_feature_design_zh.md`) explaining the root causes and solutions for all three Windows issues.

## Files Changed

| File | Changes |
|------|---------|
| `src/functions/command/utils.rs` | Core fix: `sanitize_windows_path()`, `raw_arg`, empty-template sanitize, tests |
| `src/config/core.rs` | `edit_cmd`/`open_dir_cmd` -> `Option<String>`, updated tests |
| `src/config/v0_3_0.rs` | Migration: only store non-empty cmds |
| `src/functions/command.rs` | Use `Option` fields |
| `installs/install.ps1` | Handle `ScriptName` null for `irm|iex` |
| `installs/tests/install.tests.ps1` | `irm|iex` simulation tests |
| `README.md` / `README_ZH.md` | Update Windows install commands |
| `docs/clashtui_feature_design_[en|zh].md` | Design documentation |
