### PR TITLE
fix: install a default core config that opens the 9090 external-controller

### DIFF
--- a/contrib/default_configs/mihomo/default_config.yaml
+++ b/contrib/default_configs/mihomo/default_config.yaml
@@ -1,0 +1,83 @@
+# Default standalone core configuration.
+mixed-port: 7890
+ipv6: false
+allow-lan: false
+log-level: silent
+unified-delay: true
+tcp-concurrent: true    # When domain has multiple IPs, attempt TCP handshake concurrently. One success is enough.
+
+secret: ""
+external-controller: 127.0.0.1:9090
+external-ui: uis/metacubexd
+external-ui-url: https://github.com/MetaCubeX/metacubexd/archive/refs/heads/gh-pages.zip
+
+#geodata-mode: true
+#geox-url:
+#  geoip: "https://mirror.ghproxy.com/https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/geoip-lite.dat"
+#  geosite: "https://mirror.ghproxy.com/https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/geosite.dat"
+#  mmdb: "https://mirror.ghproxy.com/https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/country-lite.mmdb"
+#  asn: "https://mirror.ghproxy.com/https://github.com/xishang0128/geoip/releases/download/latest/GeoLite2-ASN.mmdb"
+
+geo-auto-update: true
+geo-update-interval: 7
+
+#find-process-mode: strict
+#global-client-fingerprint: chrome
+
+profile:
+  store-selected: true
+  store-fake-ip: true
+
+sniffer:
+  enable: true
+  sniff:
+    HTTP:
+      ports: [80, 8080-8880]
+      override-destination: true
+    TLS:
+      ports: [443, 8443]
+    QUIC:
+      ports: [443, 8443]
+  skip-domain:
+    - "Mijia Cloud"
+    - "+.push.apple.com"
+
+tun:
+  enable: true
+  stack: mixed
+  dns-hijack:
+    - "any:53"
+    - "tcp://any:53"
+  auto-route: true
+  auto-redirect: true
+  auto-detect-interface: true
+
+dns:
+  enable: true
+  ipv6: true
+  enhanced-mode: fake-ip
+  fake-ip-filter:
+    - "*"
+    - "+.lan"
+    - "+.local"
+    - "+.market.xiaomi.com"
+    - "auth-6441.wifi.com"
+  default-nameserver:
+    - tls://223.5.5.5
+    - tls://223.6.6.6
+  nameserver:
+    - https://doh.pub/dns-query
+    - https://dns.alidns.com/dns-query
+  nameserver-policy:
+    "auth-6441.wifi.com": "system://"       # use system DNS resolver
+
+proxies: []
+
+proxy-groups:
+  - name: PROXY
+    type: select
+    proxies:
+      - DIRECT
+
+rules:
+  - MATCH,PROXY

--- a/contrib/default_configs/mihomo/default_config_no_tun.yaml
+++ b/contrib/default_configs/mihomo/default_config_no_tun.yaml
@@ -1,0 +1,46 @@
+# Default standalone core configuration.
+mixed-port: 7890
+ipv6: false
+allow-lan: false
+log-level: silent
+unified-delay: true
+tcp-concurrent: true    # When domain has multiple IPs, attempt TCP handshake concurrently. One success is enough.
+
+secret: ""
+external-controller: 127.0.0.1:9090
+external-ui: uis/metacubexd
+external-ui-url: https://github.com/MetaCubeX/metacubexd/archive/refs/heads/gh-pages.zip
+
+#geodata-mode: true
+#geox-url:
+#  geoip: "https://mirror.ghproxy.com/https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/geoip-lite.dat"
+#  geosite: "https://mirror.ghproxy.com/https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/geosite.dat"
+#  mmdb: "https://mirror.ghproxy.com/https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/country-lite.mmdb"
+#  asn: "https://mirror.ghproxy.com/https://github.com/xishang0128/geoip/releases/download/latest/GeoLite2-ASN.mmdb"
+
+geo-auto-update: true
+geo-update-interval: 7
+
+#find-process-mode: strict
+#global-client-fingerprint: chrome
+
+profile:
+  store-selected: true
+  store-fake-ip: true
+
+dns:
+  enable: false
+
+tun:
+  enable: false
+
+proxies: []
+
+proxy-groups:
+  - name: PROXY
+    type: select
+    proxies:
+      - DIRECT
+
+rules:
+  - MATCH,PROXY

--- a/installs/install
+++ b/installs/install
@@ -779,14 +779,17 @@ create_core_configs() {
     $SUDO mkdir -p "$MIHOMO_CONFIG_DIR"
 
     local mihomo_cfg_src
+    local mihomo_default_src
     if $IS_USER; then
       mihomo_cfg_src="default_configs/mihomo/core_override_config_no_tun.yaml"
+      mihomo_default_src="default_configs/mihomo/default_config_no_tun.yaml"
     else
       mihomo_cfg_src="default_configs/mihomo/core_override_config.yaml"
+      mihomo_default_src="default_configs/mihomo/default_config.yaml"
     fi
 
     # Copy core override config via contrib helper
-    copy_contrib "$mihomo_cfg_src" "${MIHOMO_CONFIG_DIR}/config.yaml"
+    copy_contrib "$mihomo_default_src" "${MIHOMO_CONFIG_DIR}/config.yaml"
     log_info "Mihomo core config written to: ${MIHOMO_CONFIG_DIR}/config.yaml"
 
     mkdir -p "$MIHOMO_USER_CONFIG_DIR"

--- a/installs/install.ps1
+++ b/installs/install.ps1
@@ -532,8 +532,9 @@ function New-CoreConfigs {
         New-Item -ItemType Directory -Path $MIHOMO_CONFIG_DIR -Force | Out-Null
 
         $cfgSrc = "default_configs/mihomo/core_override_config.yaml"
+        $defaultCfgSrc = "default_configs/mihomo/default_config.yaml"
         Backup-File (Join-Path $MIHOMO_CONFIG_DIR "config.yaml")
-        Copy-Contrib $cfgSrc (Join-Path $MIHOMO_CONFIG_DIR "config.yaml")
+        Copy-Contrib $defaultCfgSrc (Join-Path $MIHOMO_CONFIG_DIR "config.yaml")
         Write-Info "Mihomo core config written to: $MIHOMO_CONFIG_DIR/config.yaml"
 
         New-Item -ItemType Directory -Path $MIHOMO_USER_CONFIG_DIR -Force | Out-Null

--- a/installs/tests/install.bats
+++ b/installs/tests/install.bats
@@ -185,6 +185,8 @@ teardown() {
   local files=(
     "default_configs/default_keymap.yaml"
     "default_configs/default_theme.yaml"
+    "default_configs/mihomo/default_config.yaml"
+    "default_configs/mihomo/default_config_no_tun.yaml"
     "default_configs/mihomo/core_override_config.yaml"
     "default_configs/mihomo/core_override_config_no_tun.yaml"
     "default_configs/sing-box/core_override_config.json"
@@ -206,6 +208,11 @@ teardown() {
     fi
   done
   [ "$missing" -eq 0 ]
+}
+
+@test "mihomo default configs expose the 9090 external-controller" {
+  grep -q "external-controller: 127.0.0.1:9090" "$PROJECT_ROOT/contrib/default_configs/mihomo/default_config.yaml"
+  grep -q "external-controller: 127.0.0.1:9090" "$PROJECT_ROOT/contrib/default_configs/mihomo/default_config_no_tun.yaml"
 }
 
 # ---------------------------------------------------------------------------

--- a/installs/tests/verify_install.py
+++ b/installs/tests/verify_install.py
@@ -343,6 +343,17 @@ def check_no_bom(label: str, path: str) -> None:
         print(f"{GREEN}[OK]{NC} {label} no BOM: {path}")
 
 
+def check_mihomo_external_controller(path: str) -> None:
+    global ERROR_COUNT
+    with open(path) as f:
+        content = f.read()
+    if "external-controller: 127.0.0.1:9090" in content:
+        print(f"{GREEN}[OK]{NC} mihomo external-controller: 127.0.0.1:9090")
+    else:
+        print(f"{RED}[FAIL]{NC} mihomo config missing external-controller: 127.0.0.1:9090")
+        ERROR_COUNT += 1
+
+
 def check_clashtui_config(config_path, yaml, cfg) -> None:
     config_dir = os.path.dirname(os.path.realpath(config_path))
 
@@ -351,6 +362,8 @@ def check_clashtui_config(config_path, yaml, cfg) -> None:
         mihomo_cfg = mihomo_cfg.get("core", {})
     if isinstance(mihomo_cfg, dict) and mihomo_cfg.get("config_path"):
         check_no_bom("mihomo core config", mihomo_cfg["config_path"])
+        if os.path.isfile(mihomo_cfg["config_path"]):
+            check_mihomo_external_controller(mihomo_cfg["config_path"])
 
     def get_section(section_name: str) -> dict:
         section = cfg.get(section_name, {})


### PR DESCRIPTION
## Summary

On a fresh install, before any subscription is imported, the mihomo core config written to `${MIHOMO_CONFIG_DIR}/config.yaml` was the override fragment, which has no `proxies`/`proxy-groups`/`rules`. mihomo rejects that as a standalone config and falls back to its built-in default, which does not open the `127.0.0.1:9090` external-controller. clashtui then cannot reach the core and the Status page shows "Core service is not running" / "Connection refused (os error 111)". This installs a complete, runnable default core config that opens the 9090 controller from the start.

## Why this matters

`create_core_configs` in `installs/install` copied `core_override_config.yaml` to two places: the active `config.yaml` and the clashtui user dir as `core_override_config.yaml`. The override file is also merged onto an imported profile via `select()`, which overwrites top-level keys, so it must stay a fragment (no `proxies`/`rules`). Adding proxies to it directly would wipe a real subscription's nodes on profile selection. The fix keeps the override fragment unchanged and adds dedicated standalone default configs for the active `config.yaml`:

- `contrib/default_configs/mihomo/default_config.yaml` (tun) and `default_config_no_tun.yaml` (user/no-tun): the existing default settings plus a minimal runnable `proxies: []` / `proxy-groups` / `rules: [MATCH,PROXY]` block, with `external-controller: 127.0.0.1:9090`.
- `installs/install` (`create_core_configs`) and `installs/install.ps1` (`New-CoreConfigs`): write the new default config to `config.yaml` while still copying the override fragment to the clashtui user dir.

## Testing

- `bats installs/tests/install.bats` - 21/21 pass, including a new test asserting both default configs expose `external-controller: 127.0.0.1:9090`.
- `installs/tests/verify_install.py` now checks the installed mihomo core config exposes the 9090 external-controller.
- `bash -n installs/install`, `shellcheck`, and YAML parse of the new configs pass.

Fixes #89
