### PR TITLE
fix(tui): fix fzf terminal freeze and remove dead CSI-u / suspend code

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,6 +1,7 @@
 #!/bin/sh
-if ! cargo fmt -- --check; then
-    echo >&2
-    echo "rustfmt check failed. Run 'cargo fmt' and stage the changes." >&2
-    exit 1
-fi
+set -e
+
+echo "==> cargo fmt --check"
+cargo fmt --all -- --check
+
+echo "==> fmt ok"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+
+echo "==> cargo clippy"
+cargo clippy --all-targets --all-features -- -D warnings
+
+echo "==> clippy ok"

--- a/docs/development_conventions.md
+++ b/docs/development_conventions.md
@@ -88,3 +88,11 @@ Update the CHANGELOG **when releasing a new version**. Before tagging a release,
 | `Security`   | Security fixes           |
 
 Do not modify CHANGELOG in daily commits — only update it at release time. Since commit messages follow Conventional Commits, tools like [git-cliff](https://github.com/orhun/git-cliff) can auto-generate the changelog.
+
+## Git Hooks
+
+Run once after clone:
+
+```bash
+git config core.hooksPath .githooks
+```

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -131,16 +131,22 @@ pub(crate) enum ProfileTypeFilter {
 
 impl ProfileTypeFilter {
     fn matches(&self, dtype: &crate::config::database::ProfileType) -> bool {
-        match (self, dtype) {
-            (ProfileTypeFilter::File, crate::config::database::ProfileType::File) => true,
-            (ProfileTypeFilter::Url, crate::config::database::ProfileType::Url(_)) => true,
+        matches!(
+            (self, dtype),
             (
+                ProfileTypeFilter::File,
+                crate::config::database::ProfileType::File
+            ) | (
+                ProfileTypeFilter::Url,
+                crate::config::database::ProfileType::Url(_)
+            ) | (
                 ProfileTypeFilter::Template,
                 crate::config::database::ProfileType::Template { .. },
-            ) => true,
-            (ProfileTypeFilter::Singbox, crate::config::database::ProfileType::Singbox) => true,
-            _ => false,
-        }
+            ) | (
+                ProfileTypeFilter::Singbox,
+                crate::config::database::ProfileType::Singbox
+            )
+        )
     }
 }
 

--- a/src/config/core.rs
+++ b/src/config/core.rs
@@ -2,16 +2,13 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
+#[derive(Default)]
 pub enum CoreType {
     #[serde(rename = "mihomo")]
+    #[default]
     Mihomo,
     #[serde(rename = "singbox")]
     Singbox,
-}
-impl Default for CoreType {
-    fn default() -> Self {
-        Self::Mihomo
-    }
 }
 impl std::fmt::Display for CoreType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -143,17 +140,10 @@ impl Default for ConfigFile {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
+#[derive(Default)]
 pub struct Extra {
     pub edit_cmd: Option<String>,
     pub open_dir_cmd: Option<String>,
-}
-impl Default for Extra {
-    fn default() -> Self {
-        Self {
-            edit_cmd: None,
-            open_dir_cmd: None,
-        }
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]

--- a/src/config/core.rs
+++ b/src/config/core.rs
@@ -322,8 +322,8 @@ profiles:
 "#;
         let data: super::super::database::CoreProfileData = serde_yml::from_str(yaml).unwrap();
         assert_eq!(data.cur_profile.as_deref(), Some("my"));
-        assert_eq!(data.profiles.get("pf1").unwrap().no_pp, true);
-        assert_eq!(data.profiles.get("pf2").unwrap().no_pp, false);
+        assert!(data.profiles.get("pf1").unwrap().no_pp);
+        assert!(!data.profiles.get("pf2").unwrap().no_pp);
     }
 
     #[test]

--- a/src/config/database.rs
+++ b/src/config/database.rs
@@ -39,18 +39,15 @@ impl ProfileData {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub enum ProfileType {
+    #[default]
     File,
     Url(String),
-    Template { template: String },
+    Template {
+        template: String,
+    },
     Singbox,
-}
-
-impl Default for ProfileType {
-    fn default() -> Self {
-        ProfileType::File
-    }
 }
 
 impl serde::Serialize for ProfileType {
@@ -112,16 +109,16 @@ impl<'de> serde::Deserialize<'de> for ProfileType {
                 template,
                 proxy_provider_groups,
             } => {
-                if let Some(groups) = proxy_provider_groups {
-                    if !groups.is_empty() {
-                        log::warn!(
-                            "Migrating legacy Template profile '{template}': proxy_provider_groups found in database, will write to template file."
-                        );
-                        PENDING_TEMPLATE_MIGRATIONS
-                            .lock()
-                            .unwrap()
-                            .push((template.clone(), groups));
-                    }
+                if let Some(groups) = proxy_provider_groups
+                    && !groups.is_empty()
+                {
+                    log::warn!(
+                        "Migrating legacy Template profile '{template}': proxy_provider_groups found in database, will write to template file."
+                    );
+                    PENDING_TEMPLATE_MIGRATIONS
+                        .lock()
+                        .unwrap()
+                        .push((template.clone(), groups));
                 }
                 ProfileType::Template { template }
             }
@@ -166,16 +163,16 @@ impl<'de> serde::Deserialize<'de> for ProfileData {
 
         if let serde_yml::Value::Mapping(map) = value {
             let dtype = map
-                .get(&serde_yml::Value::String("dtype".into()))
+                .get(serde_yml::Value::String("dtype".into()))
                 .map(|v| serde_yml::from_value(v.clone()).map_err(serde::de::Error::custom))
                 .transpose()?
                 .unwrap_or(ProfileType::File);
             let no_pp = map
-                .get(&serde_yml::Value::String("no_pp".into()))
+                .get(serde_yml::Value::String("no_pp".into()))
                 .and_then(|v| v.as_bool())
                 .unwrap_or(false);
             let update_with_proxy = map
-                .get(&serde_yml::Value::String("update_with_proxy".into()))
+                .get(serde_yml::Value::String("update_with_proxy".into()))
                 .and_then(|v| v.as_bool())
                 .unwrap_or(false);
             Ok(ProfileData {

--- a/src/config/database.rs
+++ b/src/config/database.rs
@@ -338,19 +338,19 @@ singbox:
             db.mihomo.profiles.get("pf1").unwrap().dtype,
             ProfileType::File
         );
-        assert_eq!(db.mihomo.profiles.get("pf1").unwrap().no_pp, false);
+        assert!(!db.mihomo.profiles.get("pf1").unwrap().no_pp);
         assert_eq!(
             db.mihomo.profiles.get("pf2").unwrap().dtype,
             ProfileType::Url("https://raw.com".to_string())
         );
-        assert_eq!(db.mihomo.profiles.get("pf2").unwrap().no_pp, false);
+        assert!(!db.mihomo.profiles.get("pf2").unwrap().no_pp);
         assert_eq!(
             db.mihomo.profiles.get("pf3").unwrap().dtype,
             ProfileType::Template {
                 template: "tpl.yaml".into(),
             }
         );
-        assert_eq!(db.mihomo.profiles.get("pf3").unwrap().no_pp, false);
+        assert!(!db.mihomo.profiles.get("pf3").unwrap().no_pp);
     }
     #[test]
     fn serde_generated_migrated_to_template() {
@@ -368,7 +368,7 @@ singbox:
                 template: "my-tpl.yaml".into(),
             }
         );
-        assert_eq!(db.mihomo.profiles.get("pf1").unwrap().no_pp, false);
+        assert!(!db.mihomo.profiles.get("pf1").unwrap().no_pp);
     }
     #[test]
     fn serde_roundtrip_file_and_url() {
@@ -396,8 +396,8 @@ singbox:
   profiles: {}
 "#;
         let db: ProfileManager = serde_yml::from_str(yaml).unwrap();
-        assert_eq!(db.mihomo.profiles.get("pf1").unwrap().no_pp, false);
-        assert_eq!(db.mihomo.profiles.get("pf2").unwrap().no_pp, false);
+        assert!(!db.mihomo.profiles.get("pf1").unwrap().no_pp);
+        assert!(!db.mihomo.profiles.get("pf2").unwrap().no_pp);
     }
     #[test]
     fn new_format_preserves_no_pp() {
@@ -410,8 +410,8 @@ singbox:
   profiles: {}
 "#;
         let db: ProfileManager = serde_yml::from_str(yaml).unwrap();
-        assert_eq!(db.mihomo.profiles.get("pf1").unwrap().no_pp, true);
-        assert_eq!(db.mihomo.profiles.get("pf2").unwrap().no_pp, false);
+        assert!(db.mihomo.profiles.get("pf1").unwrap().no_pp);
+        assert!(!db.mihomo.profiles.get("pf2").unwrap().no_pp);
     }
     #[test]
     fn new_format_missing_no_pp_defaults_false() {
@@ -423,7 +423,7 @@ singbox:
   profiles: {}
 "#;
         let db: ProfileManager = serde_yml::from_str(yaml).unwrap();
-        assert_eq!(db.mihomo.profiles.get("pf1").unwrap().no_pp, false);
+        assert!(!db.mihomo.profiles.get("pf1").unwrap().no_pp);
     }
     #[test]
     fn set_no_pp_toggles_and_persists() {
@@ -458,10 +458,7 @@ singbox:
   profiles: {}
 "#;
         let db: ProfileManager = serde_yml::from_str(yaml).unwrap();
-        assert_eq!(
-            db.mihomo.profiles.get("pf1").unwrap().update_with_proxy,
-            false
-        );
+        assert!(!db.mihomo.profiles.get("pf1").unwrap().update_with_proxy);
     }
 
     #[test]

--- a/src/config/util.rs
+++ b/src/config/util.rs
@@ -41,39 +41,6 @@ pub(super) fn load_home_dir() -> Result<std::path::PathBuf> {
     }
 }
 
-#[cfg(test)]
-mod tests {
-
-    #[cfg(target_os = "macos")]
-    #[test]
-    fn load_home_dir_macos_uses_home_dot_config() {
-        // When not in portable mode, macOS uses $HOME/.config/clashtui
-        let exe_dir = std::env::current_exe()
-            .unwrap()
-            .parent()
-            .unwrap()
-            .to_path_buf();
-        let portable_data = exe_dir.join("data");
-        if portable_data.exists() && portable_data.is_dir() {
-            eprintln!("skipping: portable data dir exists at {:?}", portable_data);
-            return;
-        }
-        let result = load_home_dir().unwrap();
-        assert!(
-            result.ends_with(".config/clashtui"),
-            "expected path ending with .config/clashtui, got: {result:?}"
-        );
-    }
-
-    #[test]
-    fn cfg_macos_consistent() {
-        // cfg!(target_os = "macos") should be true when compiled with --target *-apple-darwin
-        let is_macos = cfg!(target_os = "macos");
-        // This always passes — it just documents the expected platform detection
-        assert!(is_macos || !is_macos);
-    }
-}
-
 macro_rules! load_save {
     ($id:ident, $name:expr) => {
         impl $id {
@@ -109,4 +76,37 @@ macro_rules! load_save {
             }
         }
     };
+}
+
+#[cfg(test)]
+mod tests {
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn load_home_dir_macos_uses_home_dot_config() {
+        // When not in portable mode, macOS uses $HOME/.config/clashtui
+        let exe_dir = std::env::current_exe()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .to_path_buf();
+        let portable_data = exe_dir.join("data");
+        if portable_data.exists() && portable_data.is_dir() {
+            eprintln!("skipping: portable data dir exists at {:?}", portable_data);
+            return;
+        }
+        let result = load_home_dir().unwrap();
+        assert!(
+            result.ends_with(".config/clashtui"),
+            "expected path ending with .config/clashtui, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn cfg_macos_consistent() {
+        // cfg!(target_os = "macos") should be true when compiled with --target *-apple-darwin
+        let is_macos = cfg!(target_os = "macos");
+        // This always passes — it just documents the expected platform detection
+        assert!(is_macos || !is_macos);
+    }
 }

--- a/src/config/util.rs
+++ b/src/config/util.rs
@@ -81,8 +81,8 @@ macro_rules! load_save {
                 let path = DATA_DIR.get().unwrap().join($name);
                 let fp = std::fs::File::create(&path)
                     .with_context(|| format!("Failed to create {}", path.display()))?;
-                Ok(serde_yml::to_writer(fp, &self)
-                    .with_context(|| format!("Failed to write {}", path.display()))?)
+                serde_yml::to_writer(fp, &self)
+                    .with_context(|| format!("Failed to write {}", path.display()))
             }
         }
         load_save!($id, $name, no_save);
@@ -93,8 +93,8 @@ macro_rules! load_save {
                 let path = DATA_DIR.get().unwrap().join($name);
                 let fp = std::fs::File::open(&path)
                     .with_context(|| format!("Failed to open {}", path.display()))?;
-                Ok(serde_yml::from_reader(fp)
-                    .with_context(|| format!("Failed to parse {}", path.display()))?)
+                serde_yml::from_reader(fp)
+                    .with_context(|| format!("Failed to parse {}", path.display()))
             }
         }
     };
@@ -104,8 +104,8 @@ macro_rules! load_save {
                 let path = DATA_DIR.get().unwrap().join($subdir).join($name);
                 let fp = std::fs::File::open(&path)
                     .with_context(|| format!("Failed to open {}", path.display()))?;
-                Ok(serde_yml::from_reader(fp)
-                    .with_context(|| format!("Failed to parse {}", path.display()))?)
+                serde_yml::from_reader(fp)
+                    .with_context(|| format!("Failed to parse {}", path.display()))
             }
         }
     };

--- a/src/functions/command.rs
+++ b/src/functions/command.rs
@@ -56,7 +56,7 @@ pub fn check_config(profile_path: &Path) -> anyhow::Result<()> {
                 if let Ok(mut value) = serde_json::from_str::<serde_json::Value>(&content) {
                     if value
                         .as_object_mut()
-                        .map_or(false, |obj| obj.remove("clashtui").is_some())
+                        .is_some_and(|obj| obj.remove("clashtui").is_some())
                     {
                         let tmp = profile_path.with_file_name(format!(
                             "{}.raw.json",

--- a/src/functions/command/linux.rs
+++ b/src/functions/command/linux.rs
@@ -12,18 +12,18 @@ pub fn find_files_not_group_writable(dir: &Path) -> Vec<PathBuf> {
             if path.is_dir() {
                 result.extend(find_files_not_group_writable(&path));
             }
-            if let Ok(metadata) = entry.metadata() {
-                if metadata.permissions().mode() & 0o0020 == 0 {
-                    result.push(path);
-                }
+            if let Ok(metadata) = entry.metadata()
+                && metadata.permissions().mode() & 0o0020 == 0
+            {
+                result.push(path);
             }
         }
     }
 
-    if let Ok(metadata) = std::fs::metadata(dir) {
-        if metadata.permissions().mode() & 0o0020 == 0 {
-            result.push(dir.to_path_buf());
-        }
+    if let Ok(metadata) = std::fs::metadata(dir)
+        && metadata.permissions().mode() & 0o0020 == 0
+    {
+        result.push(dir.to_path_buf());
     }
 
     result
@@ -38,28 +38,24 @@ pub fn find_files_not_in_group(dir: &Path, group_name: &str) -> Vec<PathBuf> {
             if path.is_dir() {
                 result.extend(find_files_not_in_group(&path, group_name));
             }
-            if let Ok(metadata) = entry.metadata() {
-                if let Some(group) = Group::from_gid(Gid::from_raw(metadata.gid()))
+            if let Ok(metadata) = entry.metadata()
+                && let Some(group) = Group::from_gid(Gid::from_raw(metadata.gid()))
                     .ok()
                     .flatten()
-                {
-                    if group.name != group_name {
-                        result.push(path);
-                    }
-                }
+                && group.name != group_name
+            {
+                result.push(path);
             }
         }
     }
 
-    if let Ok(metadata) = std::fs::metadata(dir) {
-        if let Some(group) = Group::from_gid(Gid::from_raw(metadata.gid()))
+    if let Ok(metadata) = std::fs::metadata(dir)
+        && let Some(group) = Group::from_gid(Gid::from_raw(metadata.gid()))
             .ok()
             .flatten()
-        {
-            if group.name != group_name {
-                result.push(dir.to_path_buf());
-            }
-        }
+        && group.name != group_name
+    {
+        result.push(dir.to_path_buf());
     }
 
     result

--- a/src/functions/file/net_resource.rs
+++ b/src/functions/file/net_resource.rs
@@ -76,7 +76,7 @@ impl ExtractNetResources for serde_yml::Mapping {
                 ResourceSection::RuleProvider => "rule-providers",
             };
 
-            let section_val = match self.get(&Value::String(key.to_string())) {
+            let section_val = match self.get(Value::String(key.to_string())) {
                 Some(Value::Mapping(map)) => map,
                 _ => continue,
             };
@@ -93,7 +93,7 @@ impl ExtractNetResources for serde_yml::Mapping {
                 };
 
                 let url = match provider_map
-                    .get(&Value::String("url".to_string()))
+                    .get(Value::String("url".to_string()))
                     .and_then(|v| v.as_str())
                 {
                     Some(s) => s.to_owned(),
@@ -101,7 +101,7 @@ impl ExtractNetResources for serde_yml::Mapping {
                 };
 
                 let path = match provider_map
-                    .get(&Value::String("path".to_string()))
+                    .get(Value::String("path".to_string()))
                     .and_then(|v| v.as_str())
                 {
                     Some(s) => s.to_owned(),
@@ -130,15 +130,15 @@ pub fn extract_singbox_net_resources(content: &serde_json::Value) -> Vec<NetReso
     if let serde_json::Value::Array(outbounds) = &content["outbounds"] {
         for outbound in outbounds {
             let name = outbound["tag"].as_str().unwrap_or("unnamed");
-            if let Some(url) = outbound["outbound"]["url"].as_str() {
-                if let Some(path) = outbound["outbound"]["path"].as_str() {
-                    resources.push(NetResource {
-                        name: name.to_owned(),
-                        url: url.to_owned(),
-                        path: path.to_owned(),
-                        section: ResourceSection::ProxyProvider,
-                    });
-                }
+            if let Some(url) = outbound["outbound"]["url"].as_str()
+                && let Some(path) = outbound["outbound"]["path"].as_str()
+            {
+                resources.push(NetResource {
+                    name: name.to_owned(),
+                    url: url.to_owned(),
+                    path: path.to_owned(),
+                    section: ResourceSection::ProxyProvider,
+                });
             }
         }
     }
@@ -147,16 +147,14 @@ pub fn extract_singbox_net_resources(content: &serde_json::Value) -> Vec<NetReso
         for rule_set in rule_sets {
             let tag = rule_set["tag"].as_str().unwrap_or("unnamed");
             let is_remote = rule_set["type"].as_str() == Some("remote");
-            if is_remote {
-                if let Some(url) = rule_set["url"].as_str() {
-                    let path = rule_set["path"].as_str().unwrap_or("rules.db");
-                    resources.push(NetResource {
-                        name: tag.to_owned(),
-                        url: url.to_owned(),
-                        path: path.to_owned(),
-                        section: ResourceSection::RuleProvider,
-                    });
-                }
+            if is_remote && let Some(url) = rule_set["url"].as_str() {
+                let path = rule_set["path"].as_str().unwrap_or("rules.db");
+                resources.push(NetResource {
+                    name: tag.to_owned(),
+                    url: url.to_owned(),
+                    path: path.to_owned(),
+                    section: ResourceSection::RuleProvider,
+                });
             }
         }
     }

--- a/src/functions/file/profile.rs
+++ b/src/functions/file/profile.rs
@@ -15,13 +15,13 @@ pub mod db {
     }
     pub fn remove(pf: Profile) -> anyhow::Result<()> {
         for path in [
-            PROFILE_JSONS_PATH.join(format!("{}.json", &pf.name)),
-            PROFILE_YAMLS_PATH.join(format!("{}.yaml", &pf.name)),
+            PROFILE_JSONS_PATH.join(format!("{}.json", pf.name)),
+            PROFILE_YAMLS_PATH.join(format!("{}.yaml", pf.name)),
         ] {
-            if let Err(e) = std::fs::remove_file(&path) {
-                if e.kind() != std::io::ErrorKind::NotFound {
-                    log::warn!("Failed to Remove profile file {}: {e}", path.display());
-                }
+            if let Err(e) = std::fs::remove_file(&path)
+                && e.kind() != std::io::ErrorKind::NotFound
+            {
+                log::warn!("Failed to Remove profile file {}: {e}", path.display());
             }
         }
         let mut pm = pm!();
@@ -151,7 +151,7 @@ pub async fn update_profile(profile: Profile, with_proxy: bool) -> anyhow::Resul
     {
         update_singbox_profile(profile.clone(), with_proxy).await
     } else {
-        let path = PROFILE_YAMLS_PATH.join(format!("{}.yaml", &profile.name));
+        let path = PROFILE_YAMLS_PATH.join(format!("{}.yaml", profile.name));
 
         if let ProfileType::Url(ref url) = profile.dtype {
             let mut response = crate::functions::restful::download::profile(url, with_proxy)?;
@@ -197,7 +197,7 @@ async fn update_singbox_profile(
     profile: Profile,
     with_proxy: bool,
 ) -> anyhow::Result<UpdateResult> {
-    let path = PROFILE_JSONS_PATH.join(format!("{}.json", &profile.name));
+    let path = PROFILE_JSONS_PATH.join(format!("{}.json", profile.name));
 
     if let ProfileType::Url(ref url) = profile.dtype {
         let mut response = crate::functions::restful::download::profile(url, with_proxy)?;
@@ -274,10 +274,10 @@ async fn update_template_profile(
                             if let Err(e) = std::io::Read::read_to_end(&mut rdr, &mut buf) {
                                 return (name, url, path, false, Some(e.to_string()));
                             }
-                            if let Some(parent) = path.parent() {
-                                if let Err(e) = std::fs::create_dir_all(parent) {
-                                    return (name, url, path, false, Some(e.to_string()));
-                                }
+                            if let Some(parent) = path.parent()
+                                && let Err(e) = std::fs::create_dir_all(parent)
+                            {
+                                return (name, url, path, false, Some(e.to_string()));
                             }
                             match std::fs::write(&path, &buf) {
                                 Ok(()) => (name, url, path, true, None),
@@ -326,17 +326,17 @@ async fn update_template_profile(
         }
 
         // Also extract standalone proxy-provider URLs from the generated profile
-        let profile_path = super::PROFILE_YAMLS_PATH.join(format!("{}.yaml", &profile.name));
-        if let Ok(content) = std::fs::read_to_string(&profile_path) {
-            if let Ok(mapping) = serde_yml::from_str::<serde_yml::Mapping>(&content) {
-                for resource in mapping.extract(&[ResourceSection::ProxyProvider]) {
-                    let already_in_groups = groups
-                        .values()
-                        .flat_map(|providers| providers.values())
-                        .any(|url| url == &resource.url);
-                    if !already_in_groups {
-                        download_urls.push((resource.name, resource.url));
-                    }
+        let profile_path = super::PROFILE_YAMLS_PATH.join(format!("{}.yaml", profile.name));
+        if let Ok(content) = std::fs::read_to_string(&profile_path)
+            && let Ok(mapping) = serde_yml::from_str::<serde_yml::Mapping>(&content)
+        {
+            for resource in mapping.extract(&[ResourceSection::ProxyProvider]) {
+                let already_in_groups = groups
+                    .values()
+                    .flat_map(|providers| providers.values())
+                    .any(|url| url == &resource.url);
+                if !already_in_groups {
+                    download_urls.push((resource.name, resource.url));
                 }
             }
         }
@@ -363,10 +363,10 @@ async fn update_template_profile(
                                 Some("Invalid YAML format".to_string()),
                             );
                         }
-                        if let Some(parent) = path.parent() {
-                            if let Err(e) = std::fs::create_dir_all(parent) {
-                                return (name, url, path, false, Some(e.to_string()));
-                            }
+                        if let Some(parent) = path.parent()
+                            && let Err(e) = std::fs::create_dir_all(parent)
+                        {
+                            return (name, url, path, false, Some(e.to_string()));
                         }
                         match std::fs::write(&path, &buf) {
                             Ok(()) => (name, url, path, true, None),
@@ -474,7 +474,7 @@ pub async fn select(profile: Profile) -> anyhow::Result<()> {
     lprofile.path = out_path.clone();
     lprofile.sync_to_disk()?;
     db::set_current(profile)?;
-    crate::functions::restful::config::reload(&out_path.display().to_string())
+    crate::functions::restful::config::reload(out_path.display().to_string())
         .map_err(|e| anyhow::anyhow!("Config written but reload failed: {e}"))?;
     Ok(())
 }
@@ -506,7 +506,7 @@ fn deep_merge(base: &mut serde_json::Value, overlay: &serde_json::Value) {
 }
 
 async fn select_singbox(profile: Profile) -> anyhow::Result<()> {
-    let profile_path = super::PROFILE_JSONS_PATH.join(format!("{}.json", &profile.name));
+    let profile_path = super::PROFILE_JSONS_PATH.join(format!("{}.json", profile.name));
     anyhow::ensure!(
         profile_path.exists(),
         "Profile {} file not found: {}. Download it first.",
@@ -553,7 +553,7 @@ async fn select_singbox(profile: Profile) -> anyhow::Result<()> {
         .map_err(|e| anyhow::anyhow!("Failed to write config to {}: {e}", out_path.display()))?;
 
     db::set_current(profile)?;
-    crate::functions::restful::config::reload(&out_path.display().to_string())
+    crate::functions::restful::config::reload(out_path.display().to_string())
         .map_err(|e| anyhow::anyhow!("Config written but reload failed: {e}"))?;
     Ok(())
 }

--- a/src/functions/file/profile.rs
+++ b/src/functions/file/profile.rs
@@ -1,3 +1,4 @@
+#[allow(clippy::module_inception)]
 mod profile;
 
 use super::PROFILE_JSONS_PATH;

--- a/src/functions/file/profile/profile.rs
+++ b/src/functions/file/profile/profile.rs
@@ -10,9 +10,9 @@ impl Profile {
         let path = if matches!(self.dtype, ProfileType::Singbox)
             || crate::config::CONFIG.core_type() == crate::config::CoreType::Singbox
         {
-            PROFILE_JSONS_PATH.join(format!("{}.json", &self.name))
+            PROFILE_JSONS_PATH.join(format!("{}.json", self.name))
         } else {
-            PROFILE_YAMLS_PATH.join(format!("{}.yaml", &self.name))
+            PROFILE_YAMLS_PATH.join(format!("{}.yaml", self.name))
         };
         let mut lpf = LocalProfile::from_pf(self, path);
         lpf.sync_from_disk()?;

--- a/src/functions/file/template.rs
+++ b/src/functions/file/template.rs
@@ -463,10 +463,10 @@ pub async fn update_profile_without_pp(
                         continue;
                     }
                     let dest = cfg_dir.join(candidate);
-                    if let Ok(buf) = std::fs::read(&dest) {
-                        if let Ok(yaml) = serde_yml::from_slice::<serde_yml::Mapping>(&buf) {
-                            return (pp_name_clone, url, candidate.to_owned(), Ok(yaml));
-                        }
+                    if let Ok(buf) = std::fs::read(&dest)
+                        && let Ok(yaml) = serde_yml::from_slice::<serde_yml::Mapping>(&buf)
+                    {
+                        return (pp_name_clone, url, candidate.to_owned(), Ok(yaml));
                     }
                 }
                 match crate::functions::restful::download::profile(&url, with_proxy) {
@@ -562,10 +562,10 @@ pub async fn update_profile_without_pp(
             download_handles.push(tokio::task::spawn_blocking(move || {
                 if !rp_path.is_empty() {
                     let dest = cfg_dir.join(&rp_path);
-                    if let Ok(buf) = std::fs::read(&dest) {
-                        if let Ok(yaml) = serde_yml::from_slice::<serde_yml::Mapping>(&buf) {
-                            return (rp_name_clone, url, rp_path, Ok(yaml));
-                        }
+                    if let Ok(buf) = std::fs::read(&dest)
+                        && let Ok(yaml) = serde_yml::from_slice::<serde_yml::Mapping>(&buf)
+                    {
+                        return (rp_name_clone, url, rp_path, Ok(yaml));
                     }
                 }
                 match crate::functions::restful::download::profile(&url, with_proxy) {
@@ -733,10 +733,10 @@ pub async fn fetch_net_resource_statuses(
                     if let Err(e) = std::io::Read::read_to_end(&mut rdr, &mut buf) {
                         return (name, url, path, section, false, Some(e.to_string()));
                     }
-                    if let Some(parent) = path.parent() {
-                        if let Err(e) = std::fs::create_dir_all(parent) {
-                            return (name, url, path, section, false, Some(e.to_string()));
-                        }
+                    if let Some(parent) = path.parent()
+                        && let Err(e) = std::fs::create_dir_all(parent)
+                    {
+                        return (name, url, path, section, false, Some(e.to_string()));
                     }
                     if serde_yml::from_slice::<serde_yml::Mapping>(&buf).is_err() {
                         return (
@@ -1138,10 +1138,10 @@ pub async fn fetch_net_resource_statuses_from_resources(
                     if let Err(e) = std::io::Read::read_to_end(&mut rdr, &mut buf) {
                         return (name, url, path, section, false, Some(e.to_string()));
                     }
-                    if let Some(parent) = path.parent() {
-                        if let Err(e) = std::fs::create_dir_all(parent) {
-                            return (name, url, path, section, false, Some(e.to_string()));
-                        }
+                    if let Some(parent) = path.parent()
+                        && let Err(e) = std::fs::create_dir_all(parent)
+                    {
+                        return (name, url, path, section, false, Some(e.to_string()));
                     }
                     if serde_yml::from_slice::<serde_yml::Mapping>(&buf).is_err() {
                         return (

--- a/src/functions/file/template.rs
+++ b/src/functions/file/template.rs
@@ -787,6 +787,84 @@ pub async fn fetch_net_resource_statuses(
     statuses
 }
 
+pub async fn fetch_net_resource_statuses_from_resources(
+    resources: &[crate::functions::file::net_resource::NetResource],
+    base_dir: &std::path::Path,
+    with_proxy: bool,
+) -> Vec<crate::functions::file::net_resource::NetResourceUpdate> {
+    use crate::functions::file::net_resource::{NetResourceUpdate, ResourceSection};
+
+    if resources.is_empty() {
+        return Vec::new();
+    }
+
+    let mut handles = Vec::with_capacity(resources.len());
+    for resource in resources.iter().cloned() {
+        let url = resource.url;
+        let name = resource.name;
+        let path = base_dir.join(&resource.path);
+        let section = resource.section;
+        handles.push(tokio::task::spawn_blocking(move || {
+            match crate::functions::restful::download::profile(&url, with_proxy) {
+                Ok(mut rdr) => {
+                    let mut buf = Vec::new();
+                    if let Err(e) = std::io::Read::read_to_end(&mut rdr, &mut buf) {
+                        return (name, url, path, section, false, Some(e.to_string()));
+                    }
+                    if let Some(parent) = path.parent()
+                        && let Err(e) = std::fs::create_dir_all(parent)
+                    {
+                        return (name, url, path, section, false, Some(e.to_string()));
+                    }
+                    if serde_yml::from_slice::<serde_yml::Mapping>(&buf).is_err() {
+                        return (
+                            name,
+                            url,
+                            path,
+                            section,
+                            false,
+                            Some("Invalid YAML format".to_string()),
+                        );
+                    }
+                    match std::fs::write(&path, &buf) {
+                        Ok(()) => (name, url, path, section, true, None),
+                        Err(e) => (name, url, path, section, false, Some(e.to_string())),
+                    }
+                }
+                Err(e) => (name, url, path, section, false, Some(e.to_string())),
+            }
+        }));
+    }
+
+    let mut statuses = Vec::with_capacity(handles.len());
+    for handle in handles {
+        let (name, url, path, section, ok, error) = match handle.await {
+            Ok(v) => v,
+            Err(e) => {
+                statuses.push(NetResourceUpdate {
+                    name: String::new(),
+                    url: String::new(),
+                    path: String::new(),
+                    section: ResourceSection::ProxyProvider,
+                    ok: false,
+                    error: Some(e.to_string()),
+                });
+                continue;
+            }
+        };
+        statuses.push(NetResourceUpdate {
+            path: path.display().to_string(),
+            name,
+            url,
+            section,
+            ok,
+            error,
+        });
+    }
+
+    statuses
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1112,82 +1190,4 @@ mod tests {
         assert_eq!(proxies, vec!["DIRECT", "HK-01", "HK-02"]);
         assert!(result_pgs[0].get("use").is_none());
     }
-}
-
-pub async fn fetch_net_resource_statuses_from_resources(
-    resources: &[crate::functions::file::net_resource::NetResource],
-    base_dir: &std::path::Path,
-    with_proxy: bool,
-) -> Vec<crate::functions::file::net_resource::NetResourceUpdate> {
-    use crate::functions::file::net_resource::{NetResourceUpdate, ResourceSection};
-
-    if resources.is_empty() {
-        return Vec::new();
-    }
-
-    let mut handles = Vec::with_capacity(resources.len());
-    for resource in resources.iter().cloned() {
-        let url = resource.url;
-        let name = resource.name;
-        let path = base_dir.join(&resource.path);
-        let section = resource.section;
-        handles.push(tokio::task::spawn_blocking(move || {
-            match crate::functions::restful::download::profile(&url, with_proxy) {
-                Ok(mut rdr) => {
-                    let mut buf = Vec::new();
-                    if let Err(e) = std::io::Read::read_to_end(&mut rdr, &mut buf) {
-                        return (name, url, path, section, false, Some(e.to_string()));
-                    }
-                    if let Some(parent) = path.parent()
-                        && let Err(e) = std::fs::create_dir_all(parent)
-                    {
-                        return (name, url, path, section, false, Some(e.to_string()));
-                    }
-                    if serde_yml::from_slice::<serde_yml::Mapping>(&buf).is_err() {
-                        return (
-                            name,
-                            url,
-                            path,
-                            section,
-                            false,
-                            Some("Invalid YAML format".to_string()),
-                        );
-                    }
-                    match std::fs::write(&path, &buf) {
-                        Ok(()) => (name, url, path, section, true, None),
-                        Err(e) => (name, url, path, section, false, Some(e.to_string())),
-                    }
-                }
-                Err(e) => (name, url, path, section, false, Some(e.to_string())),
-            }
-        }));
-    }
-
-    let mut statuses = Vec::with_capacity(handles.len());
-    for handle in handles {
-        let (name, url, path, section, ok, error) = match handle.await {
-            Ok(v) => v,
-            Err(e) => {
-                statuses.push(NetResourceUpdate {
-                    name: String::new(),
-                    url: String::new(),
-                    path: String::new(),
-                    section: ResourceSection::ProxyProvider,
-                    ok: false,
-                    error: Some(e.to_string()),
-                });
-                continue;
-            }
-        };
-        statuses.push(NetResourceUpdate {
-            path: path.display().to_string(),
-            name,
-            url,
-            section,
-            ok,
-            error,
-        });
-    }
-
-    statuses
 }

--- a/src/functions/file/template/singbox.rs
+++ b/src/functions/file/template/singbox.rs
@@ -32,9 +32,9 @@ fn save_cached_proxies(url: &str, proxies: &[JsonValue]) {
 
 #[cfg_attr(not(test), allow(dead_code))]
 fn interval_to_duration(seconds: u64) -> String {
-    if seconds >= 3600 && seconds % 3600 == 0 {
+    if seconds >= 3600 && seconds.is_multiple_of(3600) {
         format!("{}h", seconds / 3600)
-    } else if seconds >= 60 && seconds % 60 == 0 {
+    } else if seconds >= 60 && seconds.is_multiple_of(60) {
         format!("{}m", seconds / 60)
     } else {
         format!("{}s", seconds)
@@ -87,16 +87,16 @@ fn dedup_singbox_proxy_tags(
     for (pp_name, proxies) in providers {
         let mut renamed_proxies = Vec::new();
         for mut proxy in proxies {
-            if let Some(obj) = proxy.as_object_mut() {
-                if let Some(tag) = obj.get("tag").and_then(|v| v.as_str()) {
-                    let tag_str = tag.to_string();
-                    if seen.contains(&tag_str) {
-                        let new_tag = format!("{}-{}", tag_str, pp_name);
-                        seen.insert(new_tag.clone());
-                        obj.insert("tag".to_string(), JsonValue::String(new_tag));
-                    } else {
-                        seen.insert(tag_str);
-                    }
+            if let Some(obj) = proxy.as_object_mut()
+                && let Some(tag) = obj.get("tag").and_then(|v| v.as_str())
+            {
+                let tag_str = tag.to_string();
+                if seen.contains(&tag_str) {
+                    let new_tag = format!("{}-{}", tag_str, pp_name);
+                    seen.insert(new_tag.clone());
+                    obj.insert("tag".to_string(), JsonValue::String(new_tag));
+                } else {
+                    seen.insert(tag_str);
                 }
             }
             renamed_proxies.push(proxy);
@@ -162,11 +162,9 @@ pub async fn gen_template_singbox(
             let url = url.clone();
             let pp_name = pp_name.clone();
             download_handles.push(tokio::task::spawn_blocking(move || {
-                if !force_refresh {
-                    if let Some(cached) = load_cached_proxies(&url) {
-                        log::info!("Using cached proxies for {pp_name} ({})", cached.len());
-                        return (pp_name, Ok(cached));
-                    }
+                if !force_refresh && let Some(cached) = load_cached_proxies(&url) {
+                    log::info!("Using cached proxies for {pp_name} ({})", cached.len());
+                    return (pp_name, Ok(cached));
                 }
                 match download_subscription(&url, with_proxy) {
                     Ok(proxies) => {
@@ -196,14 +194,14 @@ pub async fn gen_template_singbox(
                 let tagged: Vec<JsonValue> = proxies
                     .into_iter()
                     .map(|mut proxy| {
-                        if let Some(obj) = proxy.as_object_mut() {
-                            if !obj.contains_key("tag") {
-                                let tag = format!(
-                                    "{pp_name}-{}",
-                                    obj.get("server").and_then(|v| v.as_str()).unwrap_or("node")
-                                );
-                                obj.insert("tag".to_string(), JsonValue::String(tag));
-                            }
+                        if let Some(obj) = proxy.as_object_mut()
+                            && !obj.contains_key("tag")
+                        {
+                            let tag = format!(
+                                "{pp_name}-{}",
+                                obj.get("server").and_then(|v| v.as_str()).unwrap_or("node")
+                            );
+                            obj.insert("tag".to_string(), JsonValue::String(tag));
                         }
                         proxy
                     })
@@ -406,12 +404,12 @@ pub fn expand_singbox_template(
                 ob["outbounds"] = serde_json::json!(resolved);
             }
             // Resolve ${} placeholders in default field
-            if let Some(default_val) = ob.get("default").and_then(|v| v.as_str()) {
-                if default_val.starts_with("${") && default_val.ends_with('}') {
-                    let resolved_default =
-                        resolve_default_placeholder(default_val, &pg_names, groups)?;
-                    ob["default"] = JsonValue::String(resolved_default);
-                }
+            if let Some(default_val) = ob.get("default").and_then(|v| v.as_str())
+                && default_val.starts_with("${")
+                && default_val.ends_with('}')
+            {
+                let resolved_default = resolve_default_placeholder(default_val, &pg_names, groups)?;
+                ob["default"] = JsonValue::String(resolved_default);
             }
             new_outbounds.push(ob);
         }

--- a/src/functions/restful.rs
+++ b/src/functions/restful.rs
@@ -91,7 +91,7 @@ pub mod config {
         )
         .and_then(|r| {
             if r.status_code >= 200 && r.status_code < 300 {
-                r.as_str().map(|s| s.to_owned()).map_err(|e| e)
+                r.as_str().map(|s| s.to_owned())
             } else {
                 let body = r.as_str().unwrap_or("(non-utf8 body)");
                 Err(minreq::Error::IoError(std::io::Error::other(format!(

--- a/src/functions/restful.rs
+++ b/src/functions/restful.rs
@@ -91,13 +91,13 @@ pub mod config {
         )
         .and_then(|r| {
             if r.status_code >= 200 && r.status_code < 300 {
-                r.as_str().map(|s| s.to_owned()).map_err(|e| e.into())
+                r.as_str().map(|s| s.to_owned()).map_err(|e| e)
             } else {
                 let body = r.as_str().unwrap_or("(non-utf8 body)");
-                Err(minreq::Error::IoError(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    format!("HTTP {}: {body}", r.status_code),
-                )))
+                Err(minreq::Error::IoError(std::io::Error::other(format!(
+                    "HTTP {}: {body}",
+                    r.status_code
+                ))))
             }
         })
     }
@@ -114,7 +114,7 @@ pub mod download {
     const B64: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
     fn base64_encode(input: &[u8]) -> String {
-        let mut out = String::with_capacity((input.len() + 2) / 3 * 4);
+        let mut out = String::with_capacity(input.len().div_ceil(3) * 4);
         for chunk in input.chunks(3) {
             let b = [
                 chunk[0],

--- a/src/functions/restful/utils.rs
+++ b/src/functions/restful/utils.rs
@@ -12,8 +12,7 @@ pub fn request(
     payload: Option<String>,
 ) -> Result<minreq::Response> {
     if sub_url != "/version" && crate::config::is_core_mismatch() {
-        return Err(minreq::Error::IoError(std::io::Error::new(
-            std::io::ErrorKind::Other,
+        return Err(minreq::Error::IoError(std::io::Error::other(
             "core mismatch",
         )));
     }
@@ -27,5 +26,5 @@ pub fn request(
     if let Some(s) = CONFIG.secret_for_core() {
         req = req.with_header(headers::AUTHORIZATION, format!("Bearer {s}"));
     }
-    req.with_timeout(timeout!()).send().map_err(|e| e.into())
+    req.with_timeout(timeout!()).send().map_err(|e| e)
 }

--- a/src/functions/restful/utils.rs
+++ b/src/functions/restful/utils.rs
@@ -26,5 +26,5 @@ pub fn request(
     if let Some(s) = CONFIG.secret_for_core() {
         req = req.with_header(headers::AUTHORIZATION, format!("Bearer {s}"));
     }
-    req.with_timeout(timeout!()).send().map_err(|e| e)
+    req.with_timeout(timeout!()).send()
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -36,11 +36,3 @@ pub fn restore() -> anyhow::Result<()> {
     term::teardown();
     Ok(())
 }
-
-pub fn suspend_terminal() {
-    term::suspend();
-}
-
-pub fn resume_terminal() -> anyhow::Result<()> {
-    term::resume()
-}

--- a/src/tui/agent.rs
+++ b/src/tui/agent.rs
@@ -72,10 +72,10 @@ pub fn extract_keymap_list<K: serde::de::DeserializeOwned>(
         if entry.on.len() == 1 {
             let key = entry.on[0];
             agent.insert(key, action);
-            if let Some(desc) = entry.desc {
-                if !desc.is_empty() {
-                    descs.insert(key, desc);
-                }
+            if let Some(desc) = entry.desc
+                && !desc.is_empty()
+            {
+                descs.insert(key, desc);
             }
         } else {
             chords.push((KeyCombo(entry.on), action, entry.desc.unwrap_or_default()));
@@ -134,18 +134,18 @@ pub fn extract_keymap_with_descs<K: serde::de::DeserializeOwned>(
     for (key_val, value_val) in map {
         let key: crate::tui::Key = from_value_robust(&key_val)?;
         // Try WithDesc format: { action: K, desc: String }
-        if let serde_yml::Value::Mapping(ref m) = value_val {
-            if let Some(action_val) = m.get("action") {
-                let action: K = from_value_robust(action_val)?;
-                agent.insert(key, action);
-                if let Some(desc_val) = m.get("desc") {
-                    let desc: String = from_value_robust(desc_val).unwrap_or_default();
-                    if !desc.is_empty() {
-                        descs.insert(key, desc);
-                    }
+        if let serde_yml::Value::Mapping(ref m) = value_val
+            && let Some(action_val) = m.get("action")
+        {
+            let action: K = from_value_robust(action_val)?;
+            agent.insert(key, action);
+            if let Some(desc_val) = m.get("desc") {
+                let desc: String = from_value_robust(desc_val).unwrap_or_default();
+                if !desc.is_empty() {
+                    descs.insert(key, desc);
                 }
-                continue;
             }
+            continue;
         }
         // Simple format: scalar or Action: Edit
         let action: K = from_value_robust(&value_val)?;
@@ -204,11 +204,11 @@ fn take_mapping(value: &mut serde_yml::Mapping, key: &str) -> Option<serde_yml::
 
 fn merge_mappings(base: &mut serde_yml::Mapping, override_map: &mut serde_yml::Mapping) {
     for (key, val) in override_map.iter() {
-        if let Some(serde_yml::Value::Mapping(base_map)) = base.get_mut(key) {
-            if let serde_yml::Value::Mapping(override_inner) = val {
-                merge_mappings(base_map, &mut override_inner.clone());
-                continue;
-            }
+        if let Some(serde_yml::Value::Mapping(base_map)) = base.get_mut(key)
+            && let serde_yml::Value::Mapping(override_inner) = val
+        {
+            merge_mappings(base_map, &mut override_inner.clone());
+            continue;
         }
         base.insert(key.clone(), val.clone());
     }
@@ -218,12 +218,12 @@ pub fn check_duplicate_keys(section: &str, map: &serde_yml::Mapping) {
     use std::collections::HashSet;
     let mut seen = HashSet::new();
     for key in map.keys() {
-        if let Ok(k) = serde_yml::from_value::<crate::tui::Key>(key.clone()) {
-            if !seen.insert(k) {
-                log::warn!(
-                    "duplicate key `{k}` in [{section}] keymap — later binding overwrites earlier"
-                );
-            }
+        if let Ok(k) = serde_yml::from_value::<crate::tui::Key>(key.clone())
+            && !seen.insert(k)
+        {
+            log::warn!(
+                "duplicate key `{k}` in [{section}] keymap — later binding overwrites earlier"
+            );
         }
     }
 }

--- a/src/tui/agent.rs
+++ b/src/tui/agent.rs
@@ -56,6 +56,7 @@ pub struct Entry {
     desc: Option<String>,
 }
 
+#[allow(clippy::type_complexity)]
 pub fn extract_keymap_list<K: serde::de::DeserializeOwned>(
     entries: Vec<Entry>,
 ) -> Result<(

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -7,7 +7,6 @@ use widget::chord::ChordHandler;
 use widget::help::HelpPanel;
 use widget::popmsg::PopUp;
 
-use Key;
 use crossterm::event::{KeyCode, KeyEventKind};
 use widget::tab::KeyCombo;
 
@@ -320,7 +319,7 @@ impl App {
         let candidate_count = self.chord.candidates.len();
         let cols = if candidate_count > 4 { 2 } else { 1 };
 
-        let total_height = ((candidate_count + cols - 1) / cols) as u16 + 2;
+        let total_height = candidate_count.div_ceil(cols) as u16 + 2;
         let total_width = if cols == 1 { 40 } else { 70 };
 
         let area = f.area();
@@ -346,7 +345,7 @@ impl App {
             .collect();
         let col_areas = Layout::horizontal(&col_widths).split(inner);
 
-        let items_per_col = (candidate_count + cols - 1) / cols;
+        let items_per_col = candidate_count.div_ceil(cols);
 
         let accent = Theme::get().popup.text;
 
@@ -361,7 +360,7 @@ impl App {
                     let remaining = &seq[self.chord.pressed.len()..];
                     let key_str: String = remaining
                         .iter()
-                        .map(|k| key_event_to_str(k))
+                        .map(key_event_to_str)
                         .collect::<Vec<_>>()
                         .join(" ");
                     Line::from(vec![
@@ -387,7 +386,7 @@ impl App {
         let candidate_count = self.global_chord.candidates.len();
         let cols = if candidate_count > 4 { 2 } else { 1 };
 
-        let total_height = ((candidate_count + cols - 1) / cols) as u16 + 2;
+        let total_height = candidate_count.div_ceil(cols) as u16 + 2;
         let total_width = if cols == 1 { 40 } else { 70 };
 
         let area = f.area();
@@ -413,7 +412,7 @@ impl App {
             .collect();
         let col_areas = Layout::horizontal(&col_widths).split(inner);
 
-        let items_per_col = (candidate_count + cols - 1) / cols;
+        let items_per_col = candidate_count.div_ceil(cols);
 
         let accent = Theme::get().popup.text;
 
@@ -428,7 +427,7 @@ impl App {
                     let remaining = &seq[self.global_chord.pressed.len()..];
                     let key_str: String = remaining
                         .iter()
-                        .map(|k| key_event_to_str(k))
+                        .map(key_event_to_str)
                         .collect::<Vec<_>>()
                         .join(" ");
                     Line::from(vec![
@@ -452,13 +451,13 @@ impl App {
         const TAB_COUNT: u8 = 7;
         match kv.code {
             KeyCode::Char(c @ '1'..='7') if !kv.ctrl && !kv.alt && !kv.super_ => {
-                let new_index = c as u8 - '1' as u8;
+                let new_index = c as u8 - b'1';
                 if new_index != self.tab_index {
                     self.tabs[self.tab_index as usize].on_leave();
                     self.tab_index = new_index;
                     self.tabs[self.tab_index as usize].on_enter();
                 }
-                return true;
+                true
             }
             KeyCode::Tab if !kv.ctrl && !kv.alt && !kv.super_ => {
                 let old_index = self.tab_index;
@@ -471,19 +470,19 @@ impl App {
                     self.tabs[old_index as usize].on_leave();
                     self.tabs[self.tab_index as usize].on_enter();
                 }
-                return true;
+                true
             }
             KeyCode::Char('q') if !kv.ctrl && !kv.alt && !kv.super_ => {
                 QUIT.store(true, Ordering::Relaxed);
-                return true;
+                true
             }
             KeyCode::Char('c') if kv.ctrl && !kv.alt && !kv.super_ => {
                 QUIT.store(true, Ordering::Relaxed);
-                return true;
+                true
             }
             KeyCode::Char('?') if !kv.ctrl && !kv.alt && !kv.super_ => {
                 self.help.toggle();
-                return true;
+                true
             }
             _ => false,
         }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -635,7 +635,7 @@ mod tests {
     #[test]
     fn global_chord_ctrl_g_enters_chord_mode() {
         let g = ctrl('g');
-        let shortcuts: &[(KeyCombo, &str)] = &*GLOBAL_CHORD_SHORTCUTS;
+        let shortcuts: &[(KeyCombo, &str)] = &GLOBAL_CHORD_SHORTCUTS;
         let mut ch = ChordHandler::default();
         let mut dispatched: Vec<Vec<Key>> = vec![];
         let consumed = ch.handle(&g, shortcuts, &mut |seq| dispatched.push(seq.to_vec()));

--- a/src/tui/key.rs
+++ b/src/tui/key.rs
@@ -46,15 +46,7 @@ impl Default for Key {
 impl From<KeyEvent> for Key {
     fn from(value: KeyEvent) -> Self {
         let shift = match (value.code, value.modifiers) {
-            (KeyCode::Char(c), m) => {
-                if c.is_ascii_uppercase() {
-                    true
-                } else if !c.is_ascii_alphabetic() && m.contains(KeyModifiers::SHIFT) {
-                    false
-                } else {
-                    false
-                }
-            }
+            (KeyCode::Char(c), _m) => c.is_ascii_uppercase(),
             (KeyCode::BackTab, _) => false,
             (_, m) => m.contains(KeyModifiers::SHIFT),
         };
@@ -127,6 +119,59 @@ impl FromStr for Key {
             bail!("empty key");
         }
         Ok(key)
+    }
+}
+
+impl Display for Key {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(c) = self.plain() {
+            return if c == ' ' {
+                write!(f, "<Space>")
+            } else {
+                f.write_char(c)
+            };
+        }
+
+        write!(f, "<")?;
+        if self.super_ {
+            write!(f, "D-")?;
+        }
+        if self.ctrl {
+            write!(f, "C-")?;
+        }
+        if self.alt {
+            write!(f, "A-")?;
+        }
+        if self.shift && !matches!(self.code, KeyCode::Char(_)) {
+            write!(f, "S-")?;
+        }
+
+        let code = match self.code {
+            KeyCode::Backspace => "Backspace",
+            KeyCode::Enter => "Enter",
+            KeyCode::Left => "Left",
+            KeyCode::Right => "Right",
+            KeyCode::Up => "Up",
+            KeyCode::Down => "Down",
+            KeyCode::Home => "Home",
+            KeyCode::End => "End",
+            KeyCode::PageUp => "PageUp",
+            KeyCode::PageDown => "PageDown",
+            KeyCode::Tab => "Tab",
+            KeyCode::BackTab => "BackTab",
+            KeyCode::Delete => "Delete",
+            KeyCode::Insert => "Insert",
+            KeyCode::Esc => "Esc",
+
+            KeyCode::Char(' ') => "Space",
+            KeyCode::Char(c) => {
+                f.write_char(c)?;
+                ""
+            }
+            _ => "Unknown",
+        };
+
+        write!(f, "{code}>")
     }
 }
 
@@ -212,58 +257,5 @@ mod tests {
         let k = Key::from(key_event(KeyCode::Up, KeyModifiers::SHIFT));
         assert_eq!(k.code, KeyCode::Up);
         assert!(k.shift);
-    }
-}
-
-impl Display for Key {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if let Some(c) = self.plain() {
-            return if c == ' ' {
-                write!(f, "<Space>")
-            } else {
-                f.write_char(c)
-            };
-        }
-
-        write!(f, "<")?;
-        if self.super_ {
-            write!(f, "D-")?;
-        }
-        if self.ctrl {
-            write!(f, "C-")?;
-        }
-        if self.alt {
-            write!(f, "A-")?;
-        }
-        if self.shift && !matches!(self.code, KeyCode::Char(_)) {
-            write!(f, "S-")?;
-        }
-
-        let code = match self.code {
-            KeyCode::Backspace => "Backspace",
-            KeyCode::Enter => "Enter",
-            KeyCode::Left => "Left",
-            KeyCode::Right => "Right",
-            KeyCode::Up => "Up",
-            KeyCode::Down => "Down",
-            KeyCode::Home => "Home",
-            KeyCode::End => "End",
-            KeyCode::PageUp => "PageUp",
-            KeyCode::PageDown => "PageDown",
-            KeyCode::Tab => "Tab",
-            KeyCode::BackTab => "BackTab",
-            KeyCode::Delete => "Delete",
-            KeyCode::Insert => "Insert",
-            KeyCode::Esc => "Esc",
-
-            KeyCode::Char(' ') => "Space",
-            KeyCode::Char(c) => {
-                f.write_char(c)?;
-                ""
-            }
-            _ => "Unknown",
-        };
-
-        write!(f, "{code}>")
     }
 }

--- a/src/tui/signals.rs
+++ b/src/tui/signals.rs
@@ -26,7 +26,6 @@ impl Signals {
                             libc::kill(0, SIGTSTP);
                         }
                         _ = crate::tui::hold(false);
-                        super::app::FULL_RENDER.notify_one();
                     }
                 }
             });

--- a/src/tui/tab/connections.rs
+++ b/src/tui/tab/connections.rs
@@ -693,8 +693,7 @@ mod tests {
 
     #[test]
     fn refresh_display_rows_none_when_empty() {
-        let mut c = Connections::default();
-        c.row = Some(0);
+        let mut c = Connections { row: Some(0), ..Default::default() };
         c.refresh_display_rows();
         assert!(c.row.is_none());
     }
@@ -705,11 +704,10 @@ mod tests {
         let mut c = mk_conns(conns);
         c.row = Some(0);
         // simulate Key::MoveUp handler logic inline
-        if let Some(r) = c.row {
-            if r > 0 {
+        if let Some(r) = c.row
+            && r > 0 {
                 c.row = Some(r - 1);
             }
-        }
         assert_eq!(c.row, Some(0));
     }
 
@@ -718,11 +716,10 @@ mod tests {
         let conns = &[conn("1", "a.com"), conn("2", "b.com")];
         let mut c = mk_conns(conns);
         c.row = Some(1);
-        if let Some(r) = c.row {
-            if r + 1 < c.display_rows.len() {
+        if let Some(r) = c.row
+            && r + 1 < c.display_rows.len() {
                 c.row = Some(r + 1);
             }
-        }
         assert_eq!(c.row, Some(1));
     }
 
@@ -1059,14 +1056,15 @@ impl Connections {
             SortColumn::Download => {
                 if descending {
                     self.display_rows
-                        .sort_by(|a, b| b.download.cmp(&a.download));
+                        .sort_by_key(|a| std::cmp::Reverse(a.download));
                 } else {
                     self.display_rows.sort_by_key(|a| a.download);
                 }
             }
             SortColumn::Upload => {
                 if descending {
-                    self.display_rows.sort_by(|a, b| b.upload.cmp(&a.upload));
+                    self.display_rows
+                        .sort_by_key(|a| std::cmp::Reverse(a.upload));
                 } else {
                     self.display_rows.sort_by_key(|a| a.upload);
                 }
@@ -1074,7 +1072,7 @@ impl Connections {
             SortColumn::DlSpeed => {
                 if descending {
                     self.display_rows
-                        .sort_by(|a, b| b.dl_speed.cmp(&a.dl_speed));
+                        .sort_by_key(|a| std::cmp::Reverse(a.dl_speed));
                 } else {
                     self.display_rows.sort_by_key(|a| a.dl_speed);
                 }
@@ -1082,7 +1080,7 @@ impl Connections {
             SortColumn::UlSpeed => {
                 if descending {
                     self.display_rows
-                        .sort_by(|a, b| b.ul_speed.cmp(&a.ul_speed));
+                        .sort_by_key(|a| std::cmp::Reverse(a.ul_speed));
                 } else {
                     self.display_rows.sort_by_key(|a| a.ul_speed);
                 }

--- a/src/tui/tab/connections.rs
+++ b/src/tui/tab/connections.rs
@@ -103,7 +103,7 @@ impl TryFrom<&crate::tui::Key> for Key {
     fn try_from(ev: &crate::tui::Key) -> Result<Self, Self::Error> {
         let agent = agent();
         if !agent.is_empty() {
-            return agent.get(ev).map(|act| *act).ok_or(());
+            return agent.get(ev).copied().ok_or(());
         }
         Err(())
     }
@@ -1061,15 +1061,14 @@ impl Connections {
                     self.display_rows
                         .sort_by(|a, b| b.download.cmp(&a.download));
                 } else {
-                    self.display_rows
-                        .sort_by(|a, b| a.download.cmp(&b.download));
+                    self.display_rows.sort_by_key(|a| a.download);
                 }
             }
             SortColumn::Upload => {
                 if descending {
                     self.display_rows.sort_by(|a, b| b.upload.cmp(&a.upload));
                 } else {
-                    self.display_rows.sort_by(|a, b| a.upload.cmp(&b.upload));
+                    self.display_rows.sort_by_key(|a| a.upload);
                 }
             }
             SortColumn::DlSpeed => {
@@ -1077,8 +1076,7 @@ impl Connections {
                     self.display_rows
                         .sort_by(|a, b| b.dl_speed.cmp(&a.dl_speed));
                 } else {
-                    self.display_rows
-                        .sort_by(|a, b| a.dl_speed.cmp(&b.dl_speed));
+                    self.display_rows.sort_by_key(|a| a.dl_speed);
                 }
             }
             SortColumn::UlSpeed => {
@@ -1086,8 +1084,7 @@ impl Connections {
                     self.display_rows
                         .sort_by(|a, b| b.ul_speed.cmp(&a.ul_speed));
                 } else {
-                    self.display_rows
-                        .sort_by(|a, b| a.ul_speed.cmp(&b.ul_speed));
+                    self.display_rows.sort_by_key(|a| a.ul_speed);
                 }
             }
         }

--- a/src/tui/tab/files/profile.rs
+++ b/src/tui/tab/files/profile.rs
@@ -44,15 +44,12 @@ fn parse_traffic_info(header_value: &str) -> TrafficInfo {
 
 pub fn fetch_traffic_for_url(url: &str, with_proxy: bool) {
     let url = url.to_owned();
-    std::thread::spawn(
-        move || match download::fetch_subscription_userinfo(&url, with_proxy) {
-            Ok(Some(userinfo)) => {
-                let info = parse_traffic_info(&userinfo);
-                TRAFFIC_CACHE.lock().unwrap().insert(url, info);
-            }
-            _ => {}
-        },
-    );
+    std::thread::spawn(move || {
+        if let Ok(Some(userinfo)) = download::fetch_subscription_userinfo(&url, with_proxy) {
+            let info = parse_traffic_info(&userinfo);
+            TRAFFIC_CACHE.lock().unwrap().insert(url, info);
+        }
+    });
 }
 
 fn human_bytes(bytes: u64) -> String {
@@ -293,7 +290,7 @@ impl TryFrom<&crate::tui::Key> for Key {
     fn try_from(value: &crate::tui::Key) -> Result<Self, Self::Error> {
         let agent = agent();
         if !agent.is_empty() {
-            return agent.get(value).map(|act| *act).ok_or(());
+            return agent.get(value).copied().ok_or(());
         }
 
         Ok(match value.code {
@@ -633,7 +630,7 @@ mod actions {
     }
 
     async fn delete(name: String) -> CB {
-        let rx = Confirm::title(format!("Delete profile?"))
+        let rx = Confirm::title("Delete profile?".to_string())
             .with_prompt(format!("Delete {name}?\nEnter to confirm, Esc to cancel"))
             .build_and_send();
         if rx.await.is_err() {
@@ -675,10 +672,10 @@ mod actions {
             .map(|pf| pf.update_with_proxy)
             .unwrap_or(false);
         // Fetch traffic info before updating
-        if let Some(pf) = db::get(&name) {
-            if let crate::config::database::ProfileType::Url(ref url) = pf.dtype {
-                fetch_traffic_for_url(url, with_proxy);
-            }
+        if let Some(pf) = db::get(&name)
+            && let crate::config::database::ProfileType::Url(ref url) = pf.dtype
+        {
+            fetch_traffic_for_url(url, with_proxy);
         }
         let result = update_profile(db::get(&name).unwrap(), with_proxy).await;
 
@@ -758,30 +755,29 @@ mod actions {
         let mut lines = Vec::new();
         let mut urls_to_fetch: Vec<(String, String)> = Vec::new();
 
-        if let Some(ref p) = pf {
-            if let ProfileType::Url(ref url) = p.dtype {
-                let cached = {
-                    let cache = TRAFFIC_CACHE.lock().unwrap();
-                    cache.get(url).cloned()
-                };
-                if let Some(info) = cached {
-                    let domain =
-                        crate::functions::file::profile::extract_domain(url).unwrap_or(url);
-                    let used = info.upload + info.download;
-                    let total_str = if info.total == 0 {
-                        "unlimited".to_owned()
-                    } else {
-                        format!(
-                            "{} ({:.0}%)",
-                            human_bytes(info.total),
-                            traffic_percentage(used, info.total)
-                        )
-                    };
-                    lines.push(format!("[{name}] {domain}"));
-                    lines.push(format!("  [Used: {} / {}]", human_bytes(used), total_str));
+        if let Some(ref p) = pf
+            && let ProfileType::Url(ref url) = p.dtype
+        {
+            let cached = {
+                let cache = TRAFFIC_CACHE.lock().unwrap();
+                cache.get(url).cloned()
+            };
+            if let Some(info) = cached {
+                let domain = crate::functions::file::profile::extract_domain(url).unwrap_or(url);
+                let used = info.upload + info.download;
+                let total_str = if info.total == 0 {
+                    "unlimited".to_owned()
                 } else {
-                    urls_to_fetch.push((name.clone(), url.clone()));
-                }
+                    format!(
+                        "{} ({:.0}%)",
+                        human_bytes(info.total),
+                        traffic_percentage(used, info.total)
+                    )
+                };
+                lines.push(format!("[{name}] {domain}"));
+                lines.push(format!("  [Used: {} / {}]", human_bytes(used), total_str));
+            } else {
+                urls_to_fetch.push((name.clone(), url.clone()));
             }
         }
 
@@ -799,30 +795,28 @@ mod actions {
 
         let profile_yaml_path =
             crate::functions::file::PROFILE_YAMLS_PATH.join(format!("{name}.yaml"));
-        if let Ok(content) = std::fs::read_to_string(&profile_yaml_path) {
-            if let Ok(mapping) = serde_yml::from_str::<serde_yml::Mapping>(&content) {
-                for resource in mapping.extract(&[ResourceSection::ProxyProvider]) {
-                    if !pp_urls.iter().any(|(_, u)| u == &resource.url) {
-                        pp_urls.push((resource.name.clone(), resource.url.clone()));
-                    }
+        if let Ok(content) = std::fs::read_to_string(&profile_yaml_path)
+            && let Ok(mapping) = serde_yml::from_str::<serde_yml::Mapping>(&content)
+        {
+            for resource in mapping.extract(&[ResourceSection::ProxyProvider]) {
+                if !pp_urls.iter().any(|(_, u)| u == &resource.url) {
+                    pp_urls.push((resource.name.clone(), resource.url.clone()));
                 }
             }
         }
 
         let profile_json_path =
             crate::functions::file::PROFILE_JSONS_PATH.join(format!("{name}.json"));
-        if let Ok(content) = std::fs::read_to_string(&profile_json_path) {
-            if let Ok(mapping) = serde_json::from_str::<serde_json::Value>(&content) {
-                if let Some(pp_map) = mapping.get("proxy-providers") {
-                    if let Some(obj) = pp_map.as_object() {
-                        for (pp_name, pp_val) in obj {
-                            if let Some(pp_url) = pp_val.get("url").and_then(|v| v.as_str()) {
-                                let url = pp_url.to_string();
-                                if !pp_urls.iter().any(|(_, u)| u == &url) {
-                                    pp_urls.push((pp_name.clone(), url));
-                                }
-                            }
-                        }
+        if let Ok(content) = std::fs::read_to_string(&profile_json_path)
+            && let Ok(mapping) = serde_json::from_str::<serde_json::Value>(&content)
+            && let Some(pp_map) = mapping.get("proxy-providers")
+            && let Some(obj) = pp_map.as_object()
+        {
+            for (pp_name, pp_val) in obj {
+                if let Some(pp_url) = pp_val.get("url").and_then(|v| v.as_str()) {
+                    let url = pp_url.to_string();
+                    if !pp_urls.iter().any(|(_, u)| u == &url) {
+                        pp_urls.push((pp_name.clone(), url));
                     }
                 }
             }

--- a/src/tui/tab/files/template.rs
+++ b/src/tui/tab/files/template.rs
@@ -173,7 +173,7 @@ impl TryFrom<&crate::tui::Key> for Key {
     fn try_from(value: &crate::tui::Key) -> Result<Self, Self::Error> {
         let agent = agent();
         if !agent.is_empty() {
-            return agent.get(value).map(|act| *act).ok_or(());
+            return agent.get(value).copied().ok_or(());
         }
 
         Ok(match value.code {
@@ -350,7 +350,7 @@ mod actions {
     }
 
     async fn delete(name: String) -> CB {
-        let rx = Confirm::title(format!("Delete template?"))
+        let rx = Confirm::title("Delete template?".to_string())
             .with_prompt(format!("Delete {name}?\nEnter to confirm, Esc to cancel"))
             .build_and_send();
         if rx.await.is_err() {

--- a/src/tui/tab/logs.rs
+++ b/src/tui/tab/logs.rs
@@ -78,7 +78,7 @@ impl TryFrom<&crate::tui::Key> for Key {
     fn try_from(ev: &crate::tui::Key) -> Result<Self, Self::Error> {
         let agent = agent();
         if !agent.is_empty() {
-            return agent.get(ev).map(|act| *act).ok_or(());
+            return agent.get(ev).copied().ok_or(());
         }
         Err(())
     }

--- a/src/tui/tab/mod.rs
+++ b/src/tui/tab/mod.rs
@@ -45,6 +45,7 @@ macro_rules! tri {
 
 macro_rules! mod_agent {
     ($ident:ident, [$($tokens:tt)*]) => {
+#[allow(clippy::vec_init_then_push)]
 pub(crate) mod agent {
     use super::*;
     use std::collections::HashMap;
@@ -267,6 +268,7 @@ macro_rules! enum_dispatch {
     ($vis:vis enum $ident:ident {
         $($item:ident,)+
     }) => {
+    #[allow(clippy::large_enum_variant, clippy::enum_variant_names)]
     $vis enum $ident {
         $($item($item),)+
     }

--- a/src/tui/tab/proxies.rs
+++ b/src/tui/tab/proxies.rs
@@ -108,7 +108,7 @@ impl TryFrom<&crate::tui::Key> for Key {
     fn try_from(ev: &crate::tui::Key) -> Result<Self, Self::Error> {
         let agent = agent();
         if !agent.is_empty() {
-            return agent.get(ev).map(|act| *act).ok_or(());
+            return agent.get(ev).copied().ok_or(());
         }
         Err(())
     }

--- a/src/tui/tab/proxies.rs
+++ b/src/tui/tab/proxies.rs
@@ -173,7 +173,7 @@ mod tests {
     #[test]
     fn dispatch_shortcut_matches_chord() {
         let seq: Vec<TuiKey> = vec![mk_key(KeyCode::Char('a')), mk_key(KeyCode::Char('f'))];
-        let found = all_shortcuts().iter().any(|(combo, _, _)| &**combo == seq);
+        let found = all_shortcuts().iter().any(|(combo, _, _)| **combo == seq);
         assert!(found, "dispatch_shortcut should find (a,f) chord");
     }
 
@@ -514,8 +514,7 @@ mod tests {
         assert!(
             all_shortcuts()
                 .iter()
-                .any(|(combo, key, _)| &**combo == &[a.clone(), f.clone()]
-                    && matches!(key, Key::CollapseAll)),
+                .any(|(combo, key, _)| **combo == [a, f] && matches!(key, Key::CollapseAll)),
             "af chord should dispatch CollapseAll"
         );
 
@@ -560,8 +559,7 @@ mod tests {
         let parent = content
             .tree
             .node_at(folder_idx)
-            .map(|n| n.parent.clone())
-            .flatten();
+            .and_then(|n| n.parent.clone());
 
         let siblings: Vec<&str> = content
             .tree
@@ -629,8 +627,7 @@ mod tests {
         let parent = content
             .tree
             .node_at(child_idx)
-            .map(|n| n.parent.clone())
-            .flatten();
+            .and_then(|n| n.parent.clone());
 
         let siblings: Vec<&str> = content
             .tree

--- a/src/tui/tab/proxies/content.rs
+++ b/src/tui/tab/proxies/content.rs
@@ -433,7 +433,7 @@ mod tests {
     #[test]
     fn selection_key_none_when_no_selection() {
         let (content, state) = load_fixture();
-        let mut s = state.clone();
+        let mut s = state;
         s.select(None);
         assert!(content.selection_key(&s).is_none());
     }

--- a/src/tui/tab/proxies/content.rs
+++ b/src/tui/tab/proxies/content.rs
@@ -61,15 +61,14 @@ impl Proxies {
 
     pub(crate) fn restore_selection(&self, key: Option<SelectionKey>, state: &mut ListState) {
         state.select(None);
-        if let Some((name, parent, ntype)) = key {
-            if let Some(idx) = self
+        if let Some((name, parent, ntype)) = key
+            && let Some(idx) = self
                 .tree
                 .nodes
                 .iter()
                 .position(|n| n.name == name && n.parent == parent && n.node_type == ntype)
-            {
-                state.select(Some(idx));
-            }
+        {
+            state.select(Some(idx));
         }
     }
 
@@ -93,21 +92,21 @@ impl Proxies {
                 }
             }
             super::Key::GoTop => {
-                if self.tree.len() > 0 {
+                if !self.tree.is_empty() {
                     state.select(Some(0));
                 }
             }
             super::Key::GoBottom => {
-                if self.tree.len() > 0 {
+                if !self.tree.is_empty() {
                     state.select(Some(self.tree.len().saturating_sub(1)));
                 }
             }
             super::Key::Parent => {
                 let info = self.tree.node_at(current).map(|n| n.parent.clone());
-                if let Some(Some(ref parent)) = info {
-                    if let Some(idx) = self.tree.find_folder_index(parent) {
-                        state.select(Some(idx));
-                    }
+                if let Some(Some(ref parent)) = info
+                    && let Some(idx) = self.tree.find_folder_index(parent)
+                {
+                    state.select(Some(idx));
                 }
             }
             super::Key::Expand => {
@@ -157,43 +156,43 @@ impl Proxies {
             }
             super::Key::Refresh => self.refresh(task_set),
             super::Key::SortByName => {
-                if let Some(group_name) = self.resolve_group_for_sort(current) {
-                    if let Some(idx) = self.tree.find_folder_index(&group_name) {
-                        let new_mode = if self.tree.nodes[idx].sort_mode == SortMode::ByName {
-                            SortMode::None
-                        } else {
-                            SortMode::ByName
-                        };
-                        self.tree.nodes[idx].sort_mode = new_mode;
-                        let key = self.selection_key(state);
-                        self.tree.rebuild_from_proxies(&self.proxies);
-                        self.restore_selection(key, state);
-                    }
+                if let Some(group_name) = self.resolve_group_for_sort(current)
+                    && let Some(idx) = self.tree.find_folder_index(&group_name)
+                {
+                    let new_mode = if self.tree.nodes[idx].sort_mode == SortMode::ByName {
+                        SortMode::None
+                    } else {
+                        SortMode::ByName
+                    };
+                    self.tree.nodes[idx].sort_mode = new_mode;
+                    let key = self.selection_key(state);
+                    self.tree.rebuild_from_proxies(&self.proxies);
+                    self.restore_selection(key, state);
                 }
             }
             super::Key::SortByDelay => {
-                if let Some(group_name) = self.resolve_group_for_sort(current) {
-                    if let Some(idx) = self.tree.find_folder_index(&group_name) {
-                        let new_mode = if self.tree.nodes[idx].sort_mode == SortMode::ByDelay {
-                            SortMode::None
-                        } else {
-                            SortMode::ByDelay
-                        };
-                        self.tree.nodes[idx].sort_mode = new_mode;
-                        let key = self.selection_key(state);
-                        self.tree.rebuild_from_proxies(&self.proxies);
-                        self.restore_selection(key, state);
-                    }
+                if let Some(group_name) = self.resolve_group_for_sort(current)
+                    && let Some(idx) = self.tree.find_folder_index(&group_name)
+                {
+                    let new_mode = if self.tree.nodes[idx].sort_mode == SortMode::ByDelay {
+                        SortMode::None
+                    } else {
+                        SortMode::ByDelay
+                    };
+                    self.tree.nodes[idx].sort_mode = new_mode;
+                    let key = self.selection_key(state);
+                    self.tree.rebuild_from_proxies(&self.proxies);
+                    self.restore_selection(key, state);
                 }
             }
             super::Key::ResetSort => {
-                if let Some(group_name) = self.resolve_group_for_sort(current) {
-                    if let Some(idx) = self.tree.find_folder_index(&group_name) {
-                        self.tree.nodes[idx].sort_mode = SortMode::None;
-                        let key = self.selection_key(state);
-                        self.tree.rebuild_from_proxies(&self.proxies);
-                        self.restore_selection(key, state);
-                    }
+                if let Some(group_name) = self.resolve_group_for_sort(current)
+                    && let Some(idx) = self.tree.find_folder_index(&group_name)
+                {
+                    self.tree.nodes[idx].sort_mode = SortMode::None;
+                    let key = self.selection_key(state);
+                    self.tree.rebuild_from_proxies(&self.proxies);
+                    self.restore_selection(key, state);
                 }
             }
             super::Key::GlobalSortByName => {
@@ -285,7 +284,7 @@ impl Proxies {
             }
             super::Key::GroupSelect => {
                 let node = self.tree.node_at(current);
-                let parent = node.map(|n| n.parent.clone()).flatten();
+                let parent = node.and_then(|n| n.parent.clone());
                 let group_name = parent.as_deref().unwrap_or("top");
                 let prompt = format!("Select in {group_name}");
                 let items: Vec<(String, usize)> = self
@@ -382,10 +381,10 @@ impl TabContent for Proxies {
     }
 
     fn render(&self, f: &mut Frame, area: Rect, state: &mut Self::State) {
-        if let Some(idx) = self.jump_target.take() {
-            if idx < self.tree.len() {
-                state.select(Some(idx));
-            }
+        if let Some(idx) = self.jump_target.take()
+            && idx < self.tree.len()
+        {
+            state.select(Some(idx));
         }
         super::render::render(self, f, area, state);
     }

--- a/src/tui/tab/proxies/handlers.rs
+++ b/src/tui/tab/proxies/handlers.rs
@@ -41,7 +41,7 @@ impl Proxies {
         self.error = Some(format!("Switching to {node}..."));
         self.testing_since = Some(Instant::now());
         async move {
-            let _ = tri!(
+            tri!(
                 tokio::task::spawn_blocking(move || { proxies::select_proxy(&group, &node) })
                     .await
                     .unwrap(),
@@ -49,7 +49,7 @@ impl Proxies {
             );
             let response = match tokio::time::timeout(
                 Duration::from_secs(t_secs),
-                tokio::task::spawn_blocking(|| proxies::fetch_proxies()),
+                tokio::task::spawn_blocking(proxies::fetch_proxies),
             )
             .await
             {
@@ -106,7 +106,7 @@ impl Proxies {
                     };
                     let mut response = match tokio::time::timeout(
                         Duration::from_secs(t_secs),
-                        tokio::task::spawn_blocking(|| proxies::fetch_proxies()),
+                        tokio::task::spawn_blocking(proxies::fetch_proxies),
                     )
                     .await
                     {
@@ -120,10 +120,10 @@ impl Proxies {
                         }
                     };
                     for (child_name, d) in &delays {
-                        if *d > 0 {
-                            if let Some(proxy) = response.proxies.get_mut(child_name) {
-                                proxy.history.push(proxies::DelayRecord { delay: *d });
-                            }
+                        if *d > 0
+                            && let Some(proxy) = response.proxies.get_mut(child_name)
+                        {
+                            proxy.history.push(proxies::DelayRecord { delay: *d });
                         }
                     }
                     wrapper(move |content: &mut Self| {
@@ -165,7 +165,7 @@ impl Proxies {
                     };
                     let mut response = match tokio::time::timeout(
                         Duration::from_secs(t_secs),
-                        tokio::task::spawn_blocking(|| proxies::fetch_proxies()),
+                        tokio::task::spawn_blocking(proxies::fetch_proxies),
                     )
                     .await
                     {
@@ -178,10 +178,10 @@ impl Proxies {
                             });
                         }
                     };
-                    if let (Some(d), Some(proxy)) = (delay, response.proxies.get_mut(&name)) {
-                        if d > 0 {
-                            proxy.history.push(proxies::DelayRecord { delay: d });
-                        }
+                    if let (Some(d), Some(proxy)) = (delay, response.proxies.get_mut(&name))
+                        && d > 0
+                    {
+                        proxy.history.push(proxies::DelayRecord { delay: d });
                     }
                     wrapper(move |content: &mut Self| {
                         content.proxies = response.proxies;
@@ -226,7 +226,7 @@ impl Proxies {
                     .get(name.as_str())
                     .and_then(|p| p.test_url.clone());
                 let n = name.clone();
-                match tokio::time::timeout(
+                if let Ok(Ok(Ok(delays))) = tokio::time::timeout(
                     Duration::from_secs(t_secs),
                     tokio::task::spawn_blocking(move || {
                         proxies::test_group_delay(&n, url.as_deref(), timeout)
@@ -234,8 +234,7 @@ impl Proxies {
                 )
                 .await
                 {
-                    Ok(Ok(Ok(delays))) => all_delays.extend(delays),
-                    _ => {}
+                    all_delays.extend(delays)
                 }
             }
             for name in &files {
@@ -259,7 +258,7 @@ impl Proxies {
             }
             let mut response = match tokio::time::timeout(
                 Duration::from_secs(t_secs),
-                tokio::task::spawn_blocking(|| proxies::fetch_proxies()),
+                tokio::task::spawn_blocking(proxies::fetch_proxies),
             )
             .await
             {
@@ -272,10 +271,10 @@ impl Proxies {
                 }
             };
             for (name, d) in &all_delays {
-                if *d > 0 {
-                    if let Some(proxy) = response.proxies.get_mut(name) {
-                        proxy.history.push(proxies::DelayRecord { delay: *d });
-                    }
+                if *d > 0
+                    && let Some(proxy) = response.proxies.get_mut(name)
+                {
+                    proxy.history.push(proxies::DelayRecord { delay: *d });
                 }
             }
             wrapper(move |content: &mut Self| {

--- a/src/tui/tab/proxies/render.rs
+++ b/src/tui/tab/proxies/render.rs
@@ -17,7 +17,7 @@ pub fn render(content: &Proxies, f: &mut Frame, area: Rect, state: &mut ListStat
         } else if idx >= len {
             state.select(Some(len.saturating_sub(1)));
         }
-    } else if content.tree.len() > 0 {
+    } else if !content.tree.is_empty() {
         state.select(Some(0));
     }
 
@@ -86,13 +86,13 @@ pub fn render(content: &Proxies, f: &mut Frame, area: Rect, state: &mut ListStat
             NodeType::Folder => Some(node.name.as_str()),
             NodeType::Link | NodeType::File => node.parent.as_deref(),
         };
-        if let Some(gname) = group_resolved {
-            if let Some(idx) = content.tree.find_folder_index(gname) {
-                match content.tree.nodes[idx].sort_mode {
-                    SortMode::ByDelay => footer_parts.push("delay ".to_owned()),
-                    SortMode::ByName => footer_parts.push("name ".to_owned()),
-                    SortMode::None => {}
-                }
+        if let Some(gname) = group_resolved
+            && let Some(idx) = content.tree.find_folder_index(gname)
+        {
+            match content.tree.nodes[idx].sort_mode {
+                SortMode::ByDelay => footer_parts.push("delay ".to_owned()),
+                SortMode::ByName => footer_parts.push("name ".to_owned()),
+                SortMode::None => {}
             }
         }
     }

--- a/src/tui/tab/proxies/tree.rs
+++ b/src/tui/tab/proxies/tree.rs
@@ -31,18 +31,10 @@ pub struct NodeItem {
     pub udp: bool,
 }
 
+#[derive(Default)]
 pub struct ProxyTree {
     pub nodes: Vec<NodeItem>,
     pub name_index: HashMap<String, usize>,
-}
-
-impl Default for ProxyTree {
-    fn default() -> Self {
-        Self {
-            nodes: Vec::new(),
-            name_index: HashMap::new(),
-        }
-    }
 }
 
 impl ProxyTree {
@@ -82,20 +74,20 @@ impl ProxyTree {
         let global_sort = sort_map.get("GLOBAL").copied().unwrap_or(SortMode::None);
         if global_sort == SortMode::ByName {
             top.sort();
-        } else if let Some(global) = proxies.get("GLOBAL") {
-            if let Some(ref group_all) = global.all {
-                let sort_index: Vec<&str> = group_all.iter().map(|s| s.as_str()).collect();
-                top.sort_by_key(|name| {
-                    if *name == "GLOBAL" {
-                        usize::MAX
-                    } else {
-                        sort_index
-                            .iter()
-                            .position(|&s| s == *name)
-                            .unwrap_or(usize::MAX - 1)
-                    }
-                });
-            }
+        } else if let Some(global) = proxies.get("GLOBAL")
+            && let Some(ref group_all) = global.all
+        {
+            let sort_index: Vec<&str> = group_all.iter().map(|s| s.as_str()).collect();
+            top.sort_by_key(|name| {
+                if *name == "GLOBAL" {
+                    usize::MAX
+                } else {
+                    sort_index
+                        .iter()
+                        .position(|&s| s == *name)
+                        .unwrap_or(usize::MAX - 1)
+                }
+            });
         }
 
         for name in &top {
@@ -155,51 +147,52 @@ impl ProxyTree {
             udp: proxy.udp,
         });
 
-        if has_kids && expanded {
-            if let Some(ref kids) = proxy.all {
-                let my_now = proxy.now.as_deref();
-                let ordered_kids: Vec<&String> = match sort_mode {
-                    SortMode::ByDelay => {
-                        let mut v: Vec<&String> = kids.iter().collect();
-                        v.sort_by_key(|kid| {
-                            resolve_delay(kid.as_str(), proxies)
-                                .and_then(|d| if d == 0 { None } else { Some(d) })
-                                .unwrap_or(u64::MAX)
-                        });
-                        v
-                    }
-                    SortMode::ByName => {
-                        let mut v: Vec<&String> = kids.iter().collect();
-                        v.sort();
-                        v
-                    }
-                    SortMode::None => kids.iter().collect(),
-                };
-                for kid in &ordered_kids {
-                    let is_group = proxies
-                        .get(kid.as_str())
-                        .map(|p| p.all.as_ref().map(|a| !a.is_empty()).unwrap_or(false))
-                        .unwrap_or(false);
-                    let ntype = if is_group {
-                        NodeType::Link
-                    } else {
-                        NodeType::File
-                    };
-                    let kid_proxy = proxies.get(kid.as_str());
-                    nodes.push(NodeItem {
-                        name: (*kid).clone(),
-                        depth: depth + 1,
-                        node_type: ntype,
-                        proxy_type: kid_proxy.map(|p| p.proxy_type.clone()).unwrap_or_default(),
-                        delay: resolve_delay(kid.as_str(), proxies),
-                        parent: Some(name.to_owned()),
-                        expanded: false,
-                        is_now: my_now == Some(kid.as_str()),
-                        sort_mode: SortMode::None,
-                        tcp: kid_proxy.map(|p| p.tcp).unwrap_or(false),
-                        udp: kid_proxy.map(|p| p.udp).unwrap_or(false),
+        if has_kids
+            && expanded
+            && let Some(ref kids) = proxy.all
+        {
+            let my_now = proxy.now.as_deref();
+            let ordered_kids: Vec<&String> = match sort_mode {
+                SortMode::ByDelay => {
+                    let mut v: Vec<&String> = kids.iter().collect();
+                    v.sort_by_key(|kid| {
+                        resolve_delay(kid.as_str(), proxies)
+                            .filter(|&d| d != 0)
+                            .unwrap_or(u64::MAX)
                     });
+                    v
                 }
+                SortMode::ByName => {
+                    let mut v: Vec<&String> = kids.iter().collect();
+                    v.sort();
+                    v
+                }
+                SortMode::None => kids.iter().collect(),
+            };
+            for kid in &ordered_kids {
+                let is_group = proxies
+                    .get(kid.as_str())
+                    .map(|p| p.all.as_ref().map(|a| !a.is_empty()).unwrap_or(false))
+                    .unwrap_or(false);
+                let ntype = if is_group {
+                    NodeType::Link
+                } else {
+                    NodeType::File
+                };
+                let kid_proxy = proxies.get(kid.as_str());
+                nodes.push(NodeItem {
+                    name: (*kid).clone(),
+                    depth: depth + 1,
+                    node_type: ntype,
+                    proxy_type: kid_proxy.map(|p| p.proxy_type.clone()).unwrap_or_default(),
+                    delay: resolve_delay(kid.as_str(), proxies),
+                    parent: Some(name.to_owned()),
+                    expanded: false,
+                    is_now: my_now == Some(kid.as_str()),
+                    sort_mode: SortMode::None,
+                    tcp: kid_proxy.map(|p| p.tcp).unwrap_or(false),
+                    udp: kid_proxy.map(|p| p.udp).unwrap_or(false),
+                });
             }
         }
     }
@@ -287,10 +280,8 @@ pub fn resolve_delay(
         return Some(d);
     }
     let has_kids = proxy.all.as_ref().map(|a| !a.is_empty()).unwrap_or(false);
-    if has_kids {
-        if let Some(d) = resolve_now_delay(name, proxies) {
-            return Some(d);
-        }
+    if has_kids && let Some(d) = resolve_now_delay(name, proxies) {
+        return Some(d);
     }
     if !proxy.history.is_empty() {
         return Some(0);

--- a/src/tui/tab/proxies/tree.rs
+++ b/src/tui/tab/proxies/tree.rs
@@ -108,6 +108,7 @@ impl ProxyTree {
         self.rebuild_index();
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn push_entry(
         nodes: &mut Vec<NodeItem>,
         name: &str,
@@ -591,8 +592,8 @@ mod tests {
         );
 
         assert_eq!(nodes.len(), 1);
-        assert_eq!(nodes[0].udp, true);
-        assert_eq!(nodes[0].tcp, true);
+        assert!(nodes[0].udp);
+        assert!(nodes[0].tcp);
     }
 
     #[test]
@@ -642,10 +643,10 @@ mod tests {
         );
 
         assert_eq!(nodes.len(), 2);
-        assert_eq!(nodes[0].udp, false);
-        assert_eq!(nodes[0].tcp, true);
-        assert_eq!(nodes[1].udp, false);
-        assert_eq!(nodes[1].tcp, false);
+        assert!(!nodes[0].udp);
+        assert!(nodes[0].tcp);
+        assert!(!nodes[1].udp);
+        assert!(!nodes[1].tcp);
     }
 
     #[test]
@@ -653,9 +654,9 @@ mod tests {
         let json = r#"{"proxies":{"node":{"name":"node","type":"Vmess","udp":true}}}"#;
         let response: ProxiesResponse = serde_json::from_str(json).unwrap();
         let proxy = response.proxies.get("node").unwrap();
-        assert_eq!(proxy.udp, true);
-        assert_eq!(
-            proxy.tcp, false,
+        assert!(proxy.udp);
+        assert!(
+            !proxy.tcp,
             "tcp should default to false when missing from JSON"
         );
     }
@@ -698,8 +699,8 @@ mod tests {
         );
 
         let child = nodes.iter().find(|n| n.name == "Child").unwrap();
-        assert_eq!(child.udp, true);
-        assert_eq!(child.tcp, false);
+        assert!(child.udp);
+        assert!(!child.tcp);
     }
 
     fn load_singbox_fixture() -> IndexMap<String, Proxy> {
@@ -781,8 +782,8 @@ mod tests {
         tree.expand_all(&proxies);
         let tcp_child = tree.nodes.iter().find(|n| n.name == "tcp-node");
         assert!(tcp_child.is_some());
-        assert_eq!(tcp_child.unwrap().tcp, true);
-        assert_eq!(tcp_child.unwrap().udp, false);
+        assert!(tcp_child.unwrap().tcp);
+        assert!(!tcp_child.unwrap().udp);
     }
 
     #[test]
@@ -847,7 +848,7 @@ mod tests {
         tree.expand_all(&proxies);
         let tcp = tree.nodes.iter().find(|n| n.name == "tcp-only");
         assert!(tcp.is_some());
-        assert_eq!(tcp.unwrap().tcp, true);
-        assert_eq!(tcp.unwrap().udp, false);
+        assert!(tcp.unwrap().tcp);
+        assert!(!tcp.unwrap().udp);
     }
 }

--- a/src/tui/tab/settings.rs
+++ b/src/tui/tab/settings.rs
@@ -35,7 +35,7 @@ impl TryFrom<&crate::tui::Key> for SettingsKey {
     fn try_from(ev: &crate::tui::Key) -> Result<Self, Self::Error> {
         let agent = agent();
         if !agent.is_empty() {
-            return agent.get(ev).map(|k| *k).ok_or(());
+            return agent.get(ev).copied().ok_or(());
         }
         Ok(match ev.code {
             KeyCode::Enter => Self::Execute,
@@ -130,7 +130,7 @@ impl TabContent for SettingsContent {
         }
 
         async move {
-            let result = tokio::task::spawn_blocking(|| crate::functions::restful::config::fetch())
+            let result = tokio::task::spawn_blocking(crate::functions::restful::config::fetch)
                 .await
                 .unwrap();
             match result {

--- a/src/tui/tab/settings.rs
+++ b/src/tui/tab/settings.rs
@@ -496,6 +496,22 @@ impl TabContent for SettingsContent {
     }
 }
 
+fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
+    let popup_layout = Layout::vertical([
+        Constraint::Percentage((100 - percent_y) / 2),
+        Constraint::Percentage(percent_y),
+        Constraint::Percentage((100 - percent_y) / 2),
+    ])
+    .split(area);
+
+    Layout::horizontal([
+        Constraint::Percentage((100 - percent_x) / 2),
+        Constraint::Percentage(percent_x),
+        Constraint::Percentage((100 - percent_x) / 2),
+    ])
+    .split(popup_layout[1])[1]
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -570,20 +586,4 @@ mod tests {
         assert!(!c.mode_selector_visible);
         assert!(!c.tun_selector_visible);
     }
-}
-
-fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
-    let popup_layout = Layout::vertical([
-        Constraint::Percentage((100 - percent_y) / 2),
-        Constraint::Percentage(percent_y),
-        Constraint::Percentage((100 - percent_y) / 2),
-    ])
-    .split(area);
-
-    Layout::horizontal([
-        Constraint::Percentage((100 - percent_x) / 2),
-        Constraint::Percentage(percent_x),
-        Constraint::Percentage((100 - percent_x) / 2),
-    ])
-    .split(popup_layout[1])[1]
 }

--- a/src/tui/tab/srvctl.rs
+++ b/src/tui/tab/srvctl.rs
@@ -378,10 +378,11 @@ impl TabContent for SrvCtlContent {
                             // stop all core services first
                             let stop_result = crate::functions::command::stop_all_services();
 
-                            match {
+                            let res = {
                                 crate::config::CONFIG.data.lock().unwrap().core_type = new_type;
                                 crate::config::CONFIG.save()
-                            } {
+                            };
+                            match res {
                                 Ok(()) => {
                                     // start the target core
                                     let start_result =

--- a/src/tui/tab/srvctl.rs
+++ b/src/tui/tab/srvctl.rs
@@ -1,7 +1,6 @@
 use super::dev::*;
 use crate::config::CoreType;
 #[cfg(unix)]
-use libc;
 use ratatui::style::Color;
 use ratatui::widgets::ListItem;
 
@@ -33,7 +32,7 @@ impl TryFrom<&crate::tui::Key> for SrvCtlKey {
     fn try_from(ev: &crate::tui::Key) -> Result<Self, Self::Error> {
         let agent = agent();
         if !agent.is_empty() {
-            return agent.get(ev).map(|k| *k).ok_or(());
+            return agent.get(ev).copied().ok_or(());
         }
         Ok(match ev.code {
             KeyCode::Enter => Self::Execute,
@@ -379,10 +378,10 @@ impl TabContent for SrvCtlContent {
                             // stop all core services first
                             let stop_result = crate::functions::command::stop_all_services();
 
-                            match (|| -> anyhow::Result<()> {
+                            match {
                                 crate::config::CONFIG.data.lock().unwrap().core_type = new_type;
                                 crate::config::CONFIG.save()
-                            })() {
+                            } {
                                 Ok(()) => {
                                     // start the target core
                                     let start_result =

--- a/src/tui/tab/status.rs
+++ b/src/tui/tab/status.rs
@@ -190,7 +190,7 @@ impl TabContent for Status {
                 ));
             }
         }
-        let matched = self.detected_core_type.map_or(true, |d| d == configured);
+        let matched = self.detected_core_type.is_none_or(|d| d == configured);
         if matched {
             if let Some(ref ver) = self.version {
                 lines.push(format!("version: {ver}"));

--- a/src/tui/term.rs
+++ b/src/tui/term.rs
@@ -20,10 +20,11 @@ fn probe() {
         use std::io::Read;
         let mut stdin = std::io::stdin().lock();
         let mut buf = [0u8; 32];
-        if let Ok(n) = stdin.read(&mut buf) {
-            if n > 0 && buf[..n].windows(5).any(|w| w == b"\x1b[?0u") {
-                CSI_U_ENABLED.store(true, Ordering::Relaxed);
-            }
+        if let Ok(n) = stdin.read(&mut buf)
+            && n > 0
+            && buf[..n].windows(5).any(|w| w == b"\x1b[?0u")
+        {
+            CSI_U_ENABLED.store(true, Ordering::Relaxed);
         }
     }
 }

--- a/src/tui/term.rs
+++ b/src/tui/term.rs
@@ -1,57 +1,12 @@
-use std::io::Write;
-use std::sync::atomic::{AtomicBool, Ordering};
-
 use super::utils::raw_mode;
-
-static CSI_U_ENABLED: AtomicBool = AtomicBool::new(false);
-
-fn probe() {
-    // CSI-u (kitty keyboard protocol) probe — only meaningful on Unix TTYs.
-    // On Windows, raw mode stdin reads block until a keypress, so skip entirely.
-    #[cfg(unix)]
-    {
-        let mut stdout = std::io::stdout().lock();
-        let _ = write!(stdout, "\x1b[?u");
-        let _ = stdout.flush();
-        drop(stdout);
-
-        std::thread::sleep(std::time::Duration::from_millis(50));
-
-        use std::io::Read;
-        let mut stdin = std::io::stdin().lock();
-        let mut buf = [0u8; 32];
-        if let Ok(n) = stdin.read(&mut buf)
-            && n > 0
-            && buf[..n].windows(5).any(|w| w == b"\x1b[?0u")
-        {
-            CSI_U_ENABLED.store(true, Ordering::Relaxed);
-        }
-    }
-}
-
-fn enable_csi_u() {
-    let _ = write!(std::io::stdout(), "\x1b[=5u");
-    let _ = std::io::stdout().flush();
-}
-
-fn disable_csi_u() {
-    let _ = write!(std::io::stdout(), "\x1b[=0u");
-    let _ = std::io::stdout().flush();
-}
 
 pub fn setup() -> anyhow::Result<()> {
     raw_mode::setup()?;
-    probe();
-    if CSI_U_ENABLED.load(Ordering::Relaxed) {
-        enable_csi_u();
-    }
     raw_mode::set_panic_hook();
     Ok(())
 }
 
 pub fn teardown() {
-    CSI_U_ENABLED.store(false, Ordering::Relaxed);
-    disable_csi_u();
     let _ = raw_mode::restore();
 }
 
@@ -62,19 +17,5 @@ pub fn hold(on: bool) -> anyhow::Result<()> {
         raw_mode::setup()?
     }
     super::app::FULL_RENDER.notify_one();
-    Ok(())
-}
-
-pub fn suspend() {
-    disable_csi_u();
-    let _ = raw_mode::restore();
-}
-
-pub fn resume() -> anyhow::Result<()> {
-    raw_mode::setup()?;
-    if CSI_U_ENABLED.load(Ordering::Relaxed) {
-        enable_csi_u();
-    }
-    raw_mode::set_panic_hook();
     Ok(())
 }

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -6,21 +6,12 @@ use std::sync::RwLock;
 
 #[derive(serde::Deserialize, Debug, Clone, PartialEq)]
 #[serde(default)]
+#[derive(Default)]
 pub(crate) struct StyleDef {
     pub fg: Option<Color>,
     pub bg: Option<Color>,
     #[serde(default)]
     pub bold: bool,
-}
-
-impl Default for StyleDef {
-    fn default() -> Self {
-        Self {
-            fg: None,
-            bg: None,
-            bold: false,
-        }
-    }
 }
 
 impl From<StyleDef> for Style {

--- a/src/tui/widget/dualtab.rs
+++ b/src/tui/widget/dualtab.rs
@@ -146,26 +146,26 @@ where
 {
     fn handle_key_event(&mut self, kv: &Key) {
         if self.is_focus_on_c1 {
-            if let Ok(key) = C1::Key::try_from(kv) {
-                if DualTabContent::handle_key_event(
+            if let Ok(key) = C1::Key::try_from(kv)
+                && DualTabContent::handle_key_event(
                     &mut self.content.0,
                     key,
                     &mut self.tasks,
                     &mut self.state.0,
-                ) {
-                    self.is_focus_on_c1 = false
-                }
+                )
+            {
+                self.is_focus_on_c1 = false
             }
         } else {
-            if let Ok(key) = C2::Key::try_from(kv) {
-                if DualTabContentMate::handle_key_event(
+            if let Ok(key) = C2::Key::try_from(kv)
+                && DualTabContentMate::handle_key_event(
                     &mut self.content.1,
                     key,
                     &mut self.tasks,
                     &mut self.state.1,
-                ) {
-                    self.is_focus_on_c1 = true
-                }
+                )
+            {
+                self.is_focus_on_c1 = true
             }
         }
     }

--- a/src/tui/widget/fzffind.rs
+++ b/src/tui/widget/fzffind.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::Ordering;
 
 pub fn run_fzf(items: &[String], prompt: &str) -> Option<usize> {
     crate::tui::EXT_PROC.store(true, Ordering::SeqCst);
-    crate::tui::suspend_terminal();
+    let _ = crate::tui::hold(true);
 
     let mut child = match Command::new("fzf")
         .args([
@@ -22,8 +22,8 @@ pub fn run_fzf(items: &[String], prompt: &str) -> Option<usize> {
     {
         Ok(c) => c,
         Err(e) => {
+            let _ = crate::tui::hold(false);
             crate::tui::widget::popmsg::Confirm::err(anyhow::anyhow!("fzf: {e}"));
-            let _ = crate::tui::resume_terminal();
             crate::tui::EXT_PROC.store(false, Ordering::SeqCst);
             return None;
         }
@@ -41,15 +41,14 @@ pub fn run_fzf(items: &[String], prompt: &str) -> Option<usize> {
     let output = match child.wait_with_output() {
         Ok(o) => o,
         Err(e) => {
+            let _ = crate::tui::hold(false);
             crate::tui::widget::popmsg::Confirm::err(anyhow::anyhow!("fzf wait: {e}"));
-            let _ = crate::tui::resume_terminal();
             crate::tui::EXT_PROC.store(false, Ordering::SeqCst);
             return None;
         }
     };
 
-    let _ = crate::tui::resume_terminal();
-    crate::tui::app::FULL_RENDER.notify_one();
+    let _ = crate::tui::hold(false);
     crate::tui::EXT_PROC.store(false, Ordering::SeqCst);
 
     if !output.status.success() {

--- a/src/tui/widget/help.rs
+++ b/src/tui/widget/help.rs
@@ -56,8 +56,8 @@ pub fn render_help(f: &mut ratatui::Frame, tab: &impl TuiTab) {
     let tab_cols = if tab_entries > 4 { 2 } else { 1 };
     let global_cols = if global_entries > 4 { 2 } else { 1 };
 
-    let tab_rows = ((tab_entries + tab_cols - 1) / tab_cols).max(1);
-    let global_rows = ((global_entries + global_cols - 1) / global_cols).max(1);
+    let tab_rows = tab_entries.div_ceil(tab_cols).max(1);
+    let global_rows = global_entries.div_ceil(global_cols).max(1);
 
     let total_height = 2 // borders
         + 1 // tab section header
@@ -152,7 +152,7 @@ fn render_shortcut_section(
         .collect();
     let col_areas = Layout::horizontal(&col_widths).split(body_area);
 
-    let items_per_col = (shortcuts.len() + cols - 1) / cols;
+    let items_per_col = shortcuts.len().div_ceil(cols);
 
     for (col_idx, col_area) in col_areas.iter().enumerate().take(cols) {
         let lines: Vec<Line> = shortcuts
@@ -166,7 +166,7 @@ fn render_shortcut_section(
                 } else {
                     combo
                         .iter()
-                        .map(|k| key_event_to_str(k))
+                        .map(key_event_to_str)
                         .collect::<Vec<_>>()
                         .join(" ")
                 };

--- a/src/tui/widget/mod.rs
+++ b/src/tui/widget/mod.rs
@@ -9,7 +9,7 @@ pub mod tab;
 macro_rules! new_type_impl_tuiwidget {
     ($i:ident) => {
         impl $crate::tui::TuiWidget for $i {
-            fn handle_key_event(&mut self, kv: &crate::tui::Key) {
+            fn handle_key_event(&mut self, kv: &$crate::tui::Key) {
                 self.0.handle_key_event(kv);
             }
 

--- a/src/tui/widget/mod.rs
+++ b/src/tui/widget/mod.rs
@@ -8,7 +8,7 @@ pub mod tab;
 #[macro_export]
 macro_rules! new_type_impl_tuiwidget {
     ($i:ident) => {
-        impl crate::tui::TuiWidget for $i {
+        impl $crate::tui::TuiWidget for $i {
             fn handle_key_event(&mut self, kv: &crate::tui::Key) {
                 self.0.handle_key_event(kv);
             }

--- a/src/tui/widget/popmsg.rs
+++ b/src/tui/widget/popmsg.rs
@@ -68,7 +68,7 @@ impl TuiWidget for PopUp {
 
     fn sync(&mut self) {
         while let Ok(content) = PAIR.1.lock().unwrap().try_recv() {
-            self.content.push(content.into());
+            self.content.push(content);
         }
     }
 }


### PR DESCRIPTION
## Summary

Commit 592499b ("Have user talk to `sudo` directly") introduced a **double-notify handshake** in the event loop for terminal handoff. The old `suspend_terminal()` / `resume_terminal()` helpers did not participate in this handshake, causing the fzf runner to deadlock on the second `.notified()` — the terminal would freeze after pressing Enter.

## Changes

### 1. fzffind: switch from `suspend_terminal`/`resume_terminal` to `hold()`

The fzf runner now uses `hold(true)` / `hold(false)`, matching the same double-notify contract used by the command runner and sudo. This prevents the terminal freeze.

### 2. signals (SIGTSTP): remove spurious third `notify_one()`

The SIGTSTP handler called `hold(true)` + `hold(false)` (two notifications) and then an extra `FULL_RENDER.notify_one()`. The third notification would leak into the next hold-handshake cycle and corrupt it.

### 3. Remove dead CSI-u and suspend/resume code

Dev simplified `term.rs` to remove all CSI-u (kitty keyboard protocol) handling — `probe()`, `enable_csi_u()`, `disable_csi_u()`, and the `CSI_U_ENABLED` static. The `hold()` function now only toggles raw mode.

Also removed the unused `suspend()`, `resume()`, `suspend_terminal()`, and `resume_terminal()` shims.

### 4. Add git hooks and fix clippy warnings

- Added `.githooks/pre-push` (clippy check) and updated `.githooks/pre-commit`
- Various clippy / style cleanups across the codebase